### PR TITLE
Add methods for storing input device data (Quiz Actions)

### DIFF
--- a/inquizitor/api/api_v1/endpoints/quiz/__init__.py
+++ b/inquizitor/api/api_v1/endpoints/quiz/__init__.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 
-from inquizitor.api.api_v1.endpoints.quiz import answer, choice, quiz, question
+from inquizitor.api.api_v1.endpoints.quiz import answer, choice, quiz, question, action
 
 router = APIRouter()
 router.include_router(answer.router, tags=["answer"])
 router.include_router(choice.router, tags=["choice"])
 router.include_router(quiz.router, tags=["quiz"])
 router.include_router(question.router, tags=["question"])
+router.include_router(action.router, tags=["action"])

--- a/inquizitor/api/api_v1/endpoints/quiz/action.py
+++ b/inquizitor/api/api_v1/endpoints/quiz/action.py
@@ -1,0 +1,85 @@
+import logging
+from pprint import pformat
+from sqlmodel import Session
+from typing import Any, List, Union
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi_jwt_auth import AuthJWT
+
+from inquizitor import crud, models
+from inquizitor.api import deps
+
+router = APIRouter()
+
+# @router.post("/{quiz_index}/questions/{question_id}/actions", response_model=models.QuizAction)
+# async def create_action(
+#     *,
+#     action_in: models.QuizActionCreate,
+#     db: Session = Depends(deps.get_db),
+#     current_student: models.User = Depends(deps.get_current_student),
+#     attempt: models.QuizAttempt = Depends(deps.get_attempt),
+#     quiz: models.Quiz = Depends(deps.get_quiz),
+#     question: models.QuizQuestion = Depends(deps.get_question),
+# ) -> Any:
+#     """
+#     Store the current student's action for the given attempt and quiz question.
+#     """
+
+#     action_in.student_id = student.id
+#     action_in.attempt_id = attempt.id
+#     action_in.quiz_id = quiz.id
+#     action_in.question_id = question.id
+
+#     action = crud.quiz_action.create(db, obj_in=action_in)
+
+#     return action
+
+
+# @router.get(
+#     "/{quiz_index}/questions/{question_id}",
+#     response_model=models.QuizQuestionReadWithChoices,
+# )
+# async def read_question(
+#     *,
+#     db: Session = Depends(deps.get_db),
+#     question: models.QuizQuestion = Depends(deps.get_question),
+#     current_user: models.User = Depends(deps.get_current_user),
+# ) -> Any:
+#     """
+#     Retrieve question by id.
+#     """
+
+#     return question
+
+
+# @router.put("/{quiz_index}/questions/{question_id}", response_model=models.QuizQuestion)
+# async def update_question(
+#     *,
+#     db: Session = Depends(deps.get_db),
+#     question_in: models.QuizQuestionUpdate,
+#     question: models.QuizQuestion = Depends(deps.get_question),
+#     current_author: models.User = Depends(deps.get_current_author),
+# ) -> Any:
+#     """
+#     Update question by quiz_index and question id.
+#     """
+
+#     question = crud.quiz_question.update(db, db_obj=question, obj_in=question_in)
+#     return question
+
+
+# @router.delete(
+#     "/{quiz_index}/questions/{question_id}", response_model=models.QuizQuestion
+# )
+# async def delete_question(
+#     *,
+#     db: Session = Depends(deps.get_db),
+#     question: models.QuizQuestion = Depends(deps.get_question),
+#     current_author: models.User = Depends(deps.get_current_author),
+# ) -> Any:
+#     """
+#     Delete question by id.
+#     """
+
+#     question = crud.quiz_question.remove(db, id=question.id)
+#     return question

--- a/inquizitor/api/api_v1/endpoints/quiz/action.py
+++ b/inquizitor/api/api_v1/endpoints/quiz/action.py
@@ -13,29 +13,26 @@ router = APIRouter()
 
 @router.post(
     "/{quiz_index}/questions/{question_id}/actions", 
-    response_model=List[models.QuizAction]
+    response_model=models.QuizAction
 )
-async def create_actions(
+async def create_action(
     *,
-    action_ins: List[models.QuizActionCreate],
+    action_in: models.QuizActionCreate,
     db: Session = Depends(deps.get_db),
     attempt: models.QuizAttempt = Depends(deps.get_attempt),
     question: models.QuizQuestion = Depends(deps.get_question),
 ) -> Any:
     """
-    Store the current student's actions for the given attempt and quiz question.
-    User is validated through get_attempt
+    Store the current student's action for the given attempt and quiz question.
+    User is validated through get_attempt (see api/deps.py)
     """
 
-    actions = []
-    for action_in in action_ins:
-        action_in.attempt_id = attempt.id
-        action_in.question_id = question.id
+    action_in.attempt_id = attempt.id
+    action_in.question_id = question.id
 
-        action = crud.quiz_action.create(db, obj_in=action_in)
-        actions.append(action)
+    action = crud.quiz_action.create(db, obj_in=action_in)
 
-    return actions
+    return action
 
 @router.get(
     "/{quiz_index}/questions/{question_id}/actions",

--- a/inquizitor/api/api_v1/endpoints/quiz/action.py
+++ b/inquizitor/api/api_v1/endpoints/quiz/action.py
@@ -1,7 +1,7 @@
 import logging
 from pprint import pformat
 from sqlmodel import Session
-from typing import Any, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi_jwt_auth import AuthJWT
@@ -11,75 +11,84 @@ from inquizitor.api import deps
 
 router = APIRouter()
 
-# @router.post("/{quiz_index}/questions/{question_id}/actions", response_model=models.QuizAction)
-# async def create_action(
-#     *,
-#     action_in: models.QuizActionCreate,
-#     db: Session = Depends(deps.get_db),
-#     current_student: models.User = Depends(deps.get_current_student),
-#     attempt: models.QuizAttempt = Depends(deps.get_attempt),
-#     quiz: models.Quiz = Depends(deps.get_quiz),
-#     question: models.QuizQuestion = Depends(deps.get_question),
-# ) -> Any:
-#     """
-#     Store the current student's action for the given attempt and quiz question.
-#     """
+@router.post(
+    "/{quiz_index}/questions/{question_id}/actions", 
+    response_model=List[models.QuizAction]
+)
+async def create_actions(
+    *,
+    action_ins: List[models.QuizActionCreate],
+    db: Session = Depends(deps.get_db),
+    attempt: models.QuizAttempt = Depends(deps.get_attempt),
+    question: models.QuizQuestion = Depends(deps.get_question),
+) -> Any:
+    """
+    Store the current student's actions for the given attempt and quiz question.
+    User is validated through get_attempt
+    """
 
-#     action_in.student_id = student.id
-#     action_in.attempt_id = attempt.id
-#     action_in.quiz_id = quiz.id
-#     action_in.question_id = question.id
+    actions = []
+    for action_in in action_ins:
+        action_in.attempt_id = attempt.id
+        action_in.question_id = question.id
 
-#     action = crud.quiz_action.create(db, obj_in=action_in)
+        action = crud.quiz_action.create(db, obj_in=action_in)
+        actions.append(action)
 
-#     return action
+    return actions
 
+# - [x] READ ACTIONS OF ALL PARTICIPANTS AT GIVEN QUESTION
+# - [x] READ ACTIONS OF ALL PARTICIPANTS AT GIVEN QUIZ
+# - [ ] READ ACTIONS AT GIVEN ATTEMPT QUESTION
+# - [ ] READ ACTIONS AT GIVEN ATTEMPT QUIZ
 
-# @router.get(
-#     "/{quiz_index}/questions/{question_id}",
-#     response_model=models.QuizQuestionReadWithChoices,
-# )
-# async def read_question(
-#     *,
-#     db: Session = Depends(deps.get_db),
-#     question: models.QuizQuestion = Depends(deps.get_question),
-#     current_user: models.User = Depends(deps.get_current_user),
-# ) -> Any:
-#     """
-#     Retrieve question by id.
-#     """
+@router.get(
+    "/{quiz_index}/questions/{question_id}/actions",
+    response_model=Dict[Tuple[int, str], List[models.QuizAction]],
+)
+async def read_question_actions(
+    *,
+    db: Session = Depends(deps.get_db),
+    quiz: models.Quiz = Depends(deps.get_quiz),
+    question: models.QuizQuestion = Depends(deps.get_question),
+    current_author: models.User = Depends(deps.get_current_author),
+) -> Any:
+    """
+    Retrieve actions for the given quiz question.
+    """
 
-#     return question
+    question_actions = {}
+    attempts = crud.quiz_attempt.get_multi_latest_by_quiz_id(db, quiz.id)
+    for attempt in attempts:
+        actions = crud.quiz_action.get_multi_by_question_attempt(
+            db, question_id=question.id, attempt_id=attempt.id
+        )
+        student = crud.user.get(db, attempt.student_id)
+        question_actions[(student.id, student.full_name)] = actions
 
+    return question_actions
 
-# @router.put("/{quiz_index}/questions/{question_id}", response_model=models.QuizQuestion)
-# async def update_question(
-#     *,
-#     db: Session = Depends(deps.get_db),
-#     question_in: models.QuizQuestionUpdate,
-#     question: models.QuizQuestion = Depends(deps.get_question),
-#     current_author: models.User = Depends(deps.get_current_author),
-# ) -> Any:
-#     """
-#     Update question by quiz_index and question id.
-#     """
+@router.get(
+    "/{quiz_index}/actions",
+    response_model=Dict[Tuple[int, str], List[models.QuizAction]],
+)
+async def read_quiz_actions(
+    *,
+    db: Session = Depends(deps.get_db),
+    quiz: models.Quiz = Depends(deps.get_quiz),
+    current_author: models.User = Depends(deps.get_current_author),
+) -> Any:
+    """
+    Retrieve actions for the given quiz.
+    """
 
-#     question = crud.quiz_question.update(db, db_obj=question, obj_in=question_in)
-#     return question
+    quiz_actions = {}
+    attempts = crud.quiz_attempt.get_multi_latest_by_quiz_id(db, quiz.id)
+    for attempt in attempts:
+        actions = crud.quiz_action.get_multi_by_attempt(
+            db, attempt_id=attempt.id
+        )
+        student = crud.user.get(db, attempt.student_id)
+        quiz_actions[(student.id, student.full_name)] = actions
 
-
-# @router.delete(
-#     "/{quiz_index}/questions/{question_id}", response_model=models.QuizQuestion
-# )
-# async def delete_question(
-#     *,
-#     db: Session = Depends(deps.get_db),
-#     question: models.QuizQuestion = Depends(deps.get_question),
-#     current_author: models.User = Depends(deps.get_current_author),
-# ) -> Any:
-#     """
-#     Delete question by id.
-#     """
-
-#     question = crud.quiz_question.remove(db, id=question.id)
-#     return question
+    return quiz_actions

--- a/inquizitor/api/api_v1/endpoints/quiz/action.py
+++ b/inquizitor/api/api_v1/endpoints/quiz/action.py
@@ -36,7 +36,7 @@ async def create_action(
 
 @router.get(
     "/{quiz_index}/questions/{question_id}/actions",
-    response_model=Dict[Tuple[int, str], List[models.QuizAction]],
+    response_model=List[models.QuizActions],
 )
 async def read_question_actions(
     *,
@@ -49,20 +49,22 @@ async def read_question_actions(
     Retrieve actions for the given quiz question.
     """
 
-    question_actions = {}
-    attempts = crud.quiz_attempt.get_multi_latest_by_quiz_id(db, quiz.id)
+    question_actions = []
+    attempts = crud.quiz_attempt.get_multi_latest_by_quiz_id(db, id=quiz.id)
     for attempt in attempts:
         actions = crud.quiz_action.get_multi_by_question_attempt(
             db, question_id=question.id, attempt_id=attempt.id
         )
         student = crud.user.get(db, attempt.student_id)
-        question_actions[(student.id, student.full_name)] = actions
+        question_actions.append(models.QuizActions(
+            student_id=student.id, student_name=student.full_name, actions=actions
+        ))
 
     return question_actions
 
 @router.get(
     "/{quiz_index}/actions",
-    response_model=Dict[Tuple[int, str], List[models.QuizAction]],
+    response_model=List[models.QuizActions],
 )
 async def read_quiz_actions(
     *,
@@ -74,14 +76,16 @@ async def read_quiz_actions(
     Retrieve actions for the given quiz.
     """
 
-    quiz_actions = {}
-    attempts = crud.quiz_attempt.get_multi_latest_by_quiz_id(db, quiz.id)
+    quiz_actions = []
+    attempts = crud.quiz_attempt.get_multi_latest_by_quiz_id(db, id=quiz.id)
     for attempt in attempts:
         actions = crud.quiz_action.get_multi_by_attempt(
             db, attempt_id=attempt.id
         )
         student = crud.user.get(db, attempt.student_id)
-        quiz_actions[(student.id, student.full_name)] = actions
+        quiz_actions.append(models.QuizActions(
+            student_id=student.id, student_name=student.full_name, actions=actions
+        ))
 
     return quiz_actions
 

--- a/inquizitor/api/api_v1/endpoints/quiz/action.py
+++ b/inquizitor/api/api_v1/endpoints/quiz/action.py
@@ -97,6 +97,7 @@ async def read_attempt_actions(
     *,
     db: Session = Depends(deps.get_db),
     quiz: models.Quiz = Depends(deps.get_quiz),
+    student_id: int,
     current_author: models.User = Depends(deps.get_current_author),
 ) -> Any:
     """
@@ -120,6 +121,7 @@ async def read_attempt_question_actions(
     *,
     db: Session = Depends(deps.get_db),
     quiz: models.Quiz = Depends(deps.get_quiz),
+    student_id: int,
     question: models.QuizQuestion = Depends(deps.get_question),
     current_author: models.User = Depends(deps.get_current_author),
 ) -> Any:

--- a/inquizitor/api/api_v1/endpoints/quiz/choice.py
+++ b/inquizitor/api/api_v1/endpoints/quiz/choice.py
@@ -13,7 +13,7 @@ router = APIRouter()
 
 
 @router.post("/{quiz_index}/questions/{question_id}", response_model=models.QuizChoice)
-async def create_choices(
+async def create_choice(
     *,
     db: Session = Depends(deps.get_db),
     choice_in: models.QuizChoiceCreate,

--- a/inquizitor/api/deps.py
+++ b/inquizitor/api/deps.py
@@ -171,13 +171,13 @@ def get_current_author(
     *,
     db: Session = Depends(get_db),
     quiz: models.Quiz = Depends(get_quiz),
-    current_user: models.User = Depends(get_current_user),
+    current_teacher: models.User = Depends(get_current_teacher),
 ) -> models.User:
     if not (
-        crud.user.is_superuser(current_user)
-        or crud.quiz.is_author(db, user_id=current_user.id, quiz_index=quiz.id)
+        crud.user.is_superuser(current_teacher)
+        or crud.quiz.is_author(db, user_id=current_teacher.id, quiz_index=quiz.id)
     ):
         raise HTTPException(
             status_code=400, detail="The user doesn't have enough privileges"
         )
-    return current_user
+    return current_teacher

--- a/inquizitor/api/deps.py
+++ b/inquizitor/api/deps.py
@@ -27,7 +27,7 @@ def get_current_user(
     try:
         Authorize.jwt_required()
     except JWTDecodeError as err:
-        # NOTE https://github.com/IndominusByte/fastapi-jwt-auth/issues/20
+        # https://github.com/IndominusByte/fastapi-jwt-auth/issues/20
         status_code = err.status_code
         if err.message == "Signature verification failed":
             status_code = 401

--- a/inquizitor/crud/__init__.py
+++ b/inquizitor/crud/__init__.py
@@ -7,6 +7,7 @@ from .crud_quiz import (
     quiz_student_link,
     quiz_question,
     quiz,
+    quiz_action
 )
 
 # For a new basic set of CRUD operations you could do

--- a/inquizitor/crud/crud_quiz/__init__.py
+++ b/inquizitor/crud/crud_quiz/__init__.py
@@ -4,3 +4,4 @@ from .choice import quiz_choice
 from .link import quiz_student_link
 from .question import quiz_question
 from .quiz import quiz
+from .action import quiz_action

--- a/inquizitor/crud/crud_quiz/action.py
+++ b/inquizitor/crud/crud_quiz/action.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict, Union
+from sqlmodel import Session
+from inquizitor.crud.base import CRUDBase
+from inquizitor.models import QuizAction, QuizActionCreate, QuizActionUpdate
+
+class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
+    def update(self, db: Session, *, db_obj: QuizAction, obj_in: Union[QuizActionUpdate, Dict[str, Any]]) -> None:
+        raise Exception('QuizAction does not allow updating of records')
+
+quiz_action = CRUDQuizAction(QuizAction)

--- a/inquizitor/crud/crud_quiz/action.py
+++ b/inquizitor/crud/crud_quiz/action.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Union
 from sqlmodel import Session
 from inquizitor.crud.base import CRUDBase
 from inquizitor.models import QuizAction, QuizActionCreate, QuizActionUpdate
@@ -6,5 +6,100 @@ from inquizitor.models import QuizAction, QuizActionCreate, QuizActionUpdate
 class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
     def update(self, db: Session, *, db_obj: QuizAction, obj_in: Union[QuizActionUpdate, Dict[str, Any]]) -> None:
         raise Exception('QuizAction does not allow updating of records')
+
+    def get_multi_by_student_question_attempt(
+        self, db: Session, *, student_id: int, question_id: int, attempt_id: int
+    ) -> List[QuizAction]:
+        return (
+            db.query(QuizAction)
+            .filter(
+                QuizAction.student_id == student_id,
+                QuizAction.question_id == question_id,
+                QuizAction.attempt_id == attempt_id
+            )
+            .all()
+        )
+
+    def get_multi_by_student_quiz_attempt(
+        self, db: Session, *, student_id: int, quiz_id: int, attempt_id: int
+    ) -> List[QuizAction]:
+        return (
+            db.query(QuizAction)
+            .filter(
+                QuizAction.student_id == student_id,
+                QuizAction.quiz_id == quiz_id,
+                QuizAction.attempt_id == attempt_id
+            )
+            .all()
+        )
+
+    def get_multi_by_question_attempt(
+        self, db: Session, *, question_id: int, attempt_id: int
+    ) -> List[QuizAction]:
+        return (
+            db.query(QuizAction)
+            .filter(
+                QuizAction.question_id == question_id,
+                QuizAction.attempt_id == attempt_id
+            )
+            .all()
+        )
+
+    def get_multi_by_question_attempt(
+        self, db: Session, *, question_id: int, attempt_id: int
+    ) -> List[QuizAction]:
+        return (
+            db.query(QuizAction)
+            .filter(
+                QuizAction.question_id == question_id,
+                QuizAction.attempt_id == attempt_id
+            )
+            .all()
+        )
+
+    def get_multi_by_question(
+        self, db: Session, *, question_id: int
+    ) -> List[QuizAction]:
+        return (
+            db.query(QuizAction)
+            .filter(
+                QuizAction.question_id == question_id,
+            )
+            .all()
+        )
+
+    def get_multi_by_quiz_attempt(
+        self, db: Session, *, quiz_id: int, attempt_id: int
+    ) -> List[QuizAction]:
+        return (
+            db.query(QuizAction)
+            .filter(
+                QuizAction.quiz_id == quiz_id,
+                QuizAction.attempt_id == attempt_id
+            )
+            .all()
+        )
+
+    def get_multi_by_quiz(
+        self, db: Session, *, quiz_id: int
+    ) -> List[QuizAction]:
+        return (
+            db.query(QuizAction)
+            .filter(
+                QuizAction.quiz_id == quiz_id,
+            )
+            .all()
+        )
+
+    def get_multi_by_student(
+        self, db: Session, *, student_id: int
+    ) -> List[QuizAction]:
+        return (
+            db.query(QuizAction)
+            .filter(
+                QuizAction.student_id == student_id,
+            )
+            .all()
+        )
 
 quiz_action = CRUDQuizAction(QuizAction)

--- a/inquizitor/crud/crud_quiz/action.py
+++ b/inquizitor/crud/crud_quiz/action.py
@@ -46,16 +46,26 @@ class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
             .all()
         )
 
-    # DOING: do the aggregate part
     def get_multi_by_quiz_order_by_student(
         self, db: Session, *, quiz_id: int
     ) -> List[QuizAction]:
-        """Get aggregated quiz actions per student"""
+        """Get quiz actions, order by student"""
         return (
             db.query(QuizAction)
             .join(QuizAttempt)
             .filter(QuizAttempt.quiz_id == quiz_id)
             .order_by(QuizAttempt.student_id)
+            .all()
+        )
+
+    def get_multi_by_attempt_order_by_question(
+        self, db: Session, *, attempt_id: int
+    ) -> List[QuizAction]:
+        """Get quiz actions for the given student attempt, order by question"""
+        return (
+            db.query(QuizAction)
+            .filter(QuizAction.attempt_id == attempt_id)
+            .order_by(QuizAction.question_id)
             .all()
         )
 

--- a/inquizitor/crud/crud_quiz/action.py
+++ b/inquizitor/crud/crud_quiz/action.py
@@ -69,4 +69,38 @@ class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
             .all()
         )
 
+    def get_per_student_summary_by_quiz(
+        self, db: Session, *, quiz_id: int
+    ) -> Any:
+        """Get per-student summary of actions for the given quiz"""
+        summary = dict()
+        actions = (
+            db.query(QuizAction)
+            .join(QuizAttempt)
+            .filter(QuizAttempt.quiz_id == quiz_id)
+            .order_by(QuizAttempt.student_id)
+            .all()
+        )
+        action_list = {
+            'blur': 0,
+            'focus': 0,
+            'copy_': 0,
+            'paste': 0,
+            'left_click': 0,
+            'right_click': 0,
+            'double_click': 0,
+        }
+        for action in actions:
+            student_name = action.attempt.student.username
+            summary.setdefault(student_name, dict(action_list))
+            summary[student_name]['blur'] += action.blur
+            summary[student_name]['focus'] += action.focus
+            summary[student_name]['copy_'] += action.copy_
+            summary[student_name]['paste'] += action.paste
+            summary[student_name]['left_click'] += action.left_click
+            summary[student_name]['right_click'] += action.right_click
+            summary[student_name]['double_click'] += action.double_click
+
+        return summary
+
 quiz_action = CRUDQuizAction(QuizAction)

--- a/inquizitor/crud/crud_quiz/action.py
+++ b/inquizitor/crud/crud_quiz/action.py
@@ -6,7 +6,7 @@ from inquizitor.models import QuizAttempt, QuizAction, QuizActionCreate, QuizAct
 class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
     """
     Reporting Scenarios:
-    - [ ] Reports > Quiz > Aggregate Latest Attempt Actions By Student
+    - [x] Reports > Quiz > Aggregate Latest Attempt Actions By Student == get_per_student_summary_by_quiz
     - [ ] Reports > Quiz > Aggregate Student's Latest Attempt Actions By Question
     Detection Scenarios:
     - [x] Attempt Log == get_multi_by_attempt
@@ -100,6 +100,39 @@ class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
             summary[student_name]['left_click'] += action.left_click
             summary[student_name]['right_click'] += action.right_click
             summary[student_name]['double_click'] += action.double_click
+
+        return summary
+
+    def get_per_question_summary_by_attempt(
+        self, db: Session, *, attempt_id: int
+    ) -> Any:
+        """Get per-question summary of actions for the given attempt"""
+        summary = dict()
+        actions = (
+            db.query(QuizAction)
+            .filter(QuizAction.attempt_id == attempt_id)
+            .order_by(QuizAction.question_id)
+            .all()
+        )
+        action_list = {
+            'blur': 0,
+            'focus': 0,
+            'copy_': 0,
+            'paste': 0,
+            'left_click': 0,
+            'right_click': 0,
+            'double_click': 0,
+        }
+        for action in actions:
+            question_id = action.question_id
+            summary.setdefault(question_id, dict(action_list))
+            summary[question_id]['blur'] += action.blur
+            summary[question_id]['focus'] += action.focus
+            summary[question_id]['copy_'] += action.copy_
+            summary[question_id]['paste'] += action.paste
+            summary[question_id]['left_click'] += action.left_click
+            summary[question_id]['right_click'] += action.right_click
+            summary[question_id]['double_click'] += action.double_click
 
         return summary
 

--- a/inquizitor/crud/crud_quiz/action.py
+++ b/inquizitor/crud/crud_quiz/action.py
@@ -1,38 +1,21 @@
 from typing import Any, Dict, List, Union
 from sqlmodel import Session
 from inquizitor.crud.base import CRUDBase
-from inquizitor.models import QuizAction, QuizActionCreate, QuizActionUpdate
+from inquizitor.models import QuizAttempt, QuizAction, QuizActionCreate, QuizActionUpdate
 
 class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
+    """
+    Reporting Scenarios:
+    - [ ] Reports > Quiz > Aggregate Latest Attempt Actions By Student
+    - [ ] Reports > Quiz > Aggregate Student's Latest Attempt Actions By Question
+    Detection Scenarios:
+    - [x] Attempt Log == get_multi_by_attempt
+    - [x] Attempt's Question Log == get_multi_by_question_attempt
+    """
+
     def update(self, db: Session, *, db_obj: QuizAction, obj_in: Union[QuizActionUpdate, Dict[str, Any]]) -> None:
         raise Exception('QuizAction does not allow updating of records')
 
-    def get_multi_by_student_question_attempt(
-        self, db: Session, *, student_id: int, question_id: int, attempt_id: int
-    ) -> List[QuizAction]:
-        return (
-            db.query(QuizAction)
-            .filter(
-                QuizAction.student_id == student_id,
-                QuizAction.question_id == question_id,
-                QuizAction.attempt_id == attempt_id
-            )
-            .all()
-        )
-
-    def get_multi_by_student_quiz_attempt(
-        self, db: Session, *, student_id: int, quiz_id: int, attempt_id: int
-    ) -> List[QuizAction]:
-        return (
-            db.query(QuizAction)
-            .filter(
-                QuizAction.student_id == student_id,
-                QuizAction.quiz_id == quiz_id,
-                QuizAction.attempt_id == attempt_id
-            )
-            .all()
-        )
-
     def get_multi_by_question_attempt(
         self, db: Session, *, question_id: int, attempt_id: int
     ) -> List[QuizAction]:
@@ -45,15 +28,12 @@ class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
             .all()
         )
 
-    def get_multi_by_question_attempt(
-        self, db: Session, *, question_id: int, attempt_id: int
+    def get_multi_by_attempt(
+        self, db: Session, *, attempt_id: int
     ) -> List[QuizAction]:
         return (
             db.query(QuizAction)
-            .filter(
-                QuizAction.question_id == question_id,
-                QuizAction.attempt_id == attempt_id
-            )
+            .filter(QuizAction.attempt_id == attempt_id)
             .all()
         )
 
@@ -62,43 +42,20 @@ class CRUDQuizAction(CRUDBase[QuizAction, QuizActionCreate, QuizActionUpdate]):
     ) -> List[QuizAction]:
         return (
             db.query(QuizAction)
-            .filter(
-                QuizAction.question_id == question_id,
-            )
+            .filter(QuizAction.question_id == question_id)
             .all()
         )
 
-    def get_multi_by_quiz_attempt(
-        self, db: Session, *, quiz_id: int, attempt_id: int
-    ) -> List[QuizAction]:
-        return (
-            db.query(QuizAction)
-            .filter(
-                QuizAction.quiz_id == quiz_id,
-                QuizAction.attempt_id == attempt_id
-            )
-            .all()
-        )
-
-    def get_multi_by_quiz(
+    # DOING: do the aggregate part
+    def get_multi_by_quiz_order_by_student(
         self, db: Session, *, quiz_id: int
     ) -> List[QuizAction]:
+        """Get aggregated quiz actions per student"""
         return (
             db.query(QuizAction)
-            .filter(
-                QuizAction.quiz_id == quiz_id,
-            )
-            .all()
-        )
-
-    def get_multi_by_student(
-        self, db: Session, *, student_id: int
-    ) -> List[QuizAction]:
-        return (
-            db.query(QuizAction)
-            .filter(
-                QuizAction.student_id == student_id,
-            )
+            .join(QuizAttempt)
+            .filter(QuizAttempt.quiz_id == quiz_id)
+            .order_by(QuizAttempt.student_id)
             .all()
         )
 

--- a/inquizitor/crud/crud_quiz/attempt.py
+++ b/inquizitor/crud/crud_quiz/attempt.py
@@ -50,8 +50,9 @@ class CRUDQuizAttempt(CRUDBase[QuizAttempt, QuizAttemptCreate, QuizAttemptUpdate
             .order_by(QuizAttempt.id.desc())
             .all()
         )
+        unique_quiz_ids = [attempt.quiz_id for attempt in unique_attempts]
         for attempt in attempts:
-            if attempt.quiz_id not in [attempt.quiz_id for attempt in unique_attempts]:
+            if attempt.quiz_id not in unique_quiz_ids:
                 unique_attempts.append(attempt)
 
         return unique_attempts
@@ -65,10 +66,9 @@ class CRUDQuizAttempt(CRUDBase[QuizAttempt, QuizAttemptCreate, QuizAttemptUpdate
             .order_by(QuizAttempt.id.desc())
             .all()
         )
+        unique_student_ids = [attempt.student_id for attempt in unique_attempts]
         for attempt in attempts:
-            if attempt.student_id not in [
-                attempt.student_id for attempt in unique_attempts
-            ]:
+            if attempt.student_id not in unique_student_ids:
                 unique_attempts.append(attempt)
 
         return unique_attempts

--- a/inquizitor/crud/crud_quiz/attempt.py
+++ b/inquizitor/crud/crud_quiz/attempt.py
@@ -27,7 +27,7 @@ class CRUDQuizAttempt(CRUDBase[QuizAttempt, QuizAttemptCreate, QuizAttemptUpdate
 
     def get_multi_by_quiz_and_student_ids(
         self, db: Session, *, quiz_id: int, student_id: int
-    ) -> QuizAttempt:
+    ) -> List[QuizAttempt]:
         """Read all attempts of student for the given quiz"""
 
         return (

--- a/inquizitor/crud/crud_quiz/choice.py
+++ b/inquizitor/crud/crud_quiz/choice.py
@@ -1,11 +1,7 @@
-from sqlmodel import Session
-
 from inquizitor.crud.base import CRUDBase
 from inquizitor.models import QuizChoice, QuizChoiceCreate, QuizChoiceUpdate
 
-
 class CRUDQuizChoice(CRUDBase[QuizChoice, QuizChoiceCreate, QuizChoiceUpdate]):
     pass
-
 
 quiz_choice = CRUDQuizChoice(QuizChoice)

--- a/inquizitor/models/__init__.py
+++ b/inquizitor/models/__init__.py
@@ -20,6 +20,9 @@ from .quiz import (
     Quiz,
     QuizCreate,
     QuizUpdate,
+    QuizAction,
+    QuizActionCreate,
+    QuizActionUpdate,
 )
 from .token import Token, TokenPayload, RevokedToken
 from .user import User, UserCreate, UserUpdate, ShowUser

--- a/inquizitor/models/__init__.py
+++ b/inquizitor/models/__init__.py
@@ -24,6 +24,7 @@ from .quiz import (
     QuizAction,
     QuizActionCreate,
     QuizActionUpdate,
+    QuizActions,
 )
 from .token import Token, TokenPayload, RevokedToken
 from .user import User, UserCreate, UserUpdate, ShowUser

--- a/inquizitor/models/quiz/__init__.py
+++ b/inquizitor/models/quiz/__init__.py
@@ -9,3 +9,4 @@ from .question import (
     QuizQuestionReadWithChoices,
 )
 from .quiz import Quiz, QuizCreate, QuizUpdate, QuizReadWithQuestions
+from .action import QuizAction, QuizActionCreate, QuizActionUpdate

--- a/inquizitor/models/quiz/__init__.py
+++ b/inquizitor/models/quiz/__init__.py
@@ -10,4 +10,4 @@ from .question import (
     QuizQuestionReadWithChoices,
 )
 from .quiz import Quiz, QuizCreate, QuizUpdate, QuizReadWithQuestions
-from .action import QuizAction, QuizActionCreate, QuizActionUpdate
+from .action import QuizAction, QuizActionCreate, QuizActionUpdate, QuizActions

--- a/inquizitor/models/quiz/action.py
+++ b/inquizitor/models/quiz/action.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import logging
 from inquizitor.db.base_class import PKModel
-from pydantic import validator
+from pydantic import root_validator, validator
 from sqlmodel import Field, SQLModel, Relationship
 from typing import Optional
 
@@ -22,7 +22,9 @@ class QuizActionBase(SQLModel):
     right_click: int = Field(default=0)
     double_click: int = Field(default=0)
 
-    # TODO
+    # @root_validator(pre=True)
+    # def check_has_action(cls, values):
+
     # @validator('blur', 'focus', 'copy_', 'paste', 'left_click', 'right_click', 'double_click')
     # def check_has_action(cls, v, values, **kwargs):
     #     logging.info(f"{values}\n")

--- a/inquizitor/models/quiz/action.py
+++ b/inquizitor/models/quiz/action.py
@@ -7,9 +7,7 @@ from typing import Optional
 
 class QuizActionBase(SQLModel):
     # these fields are optional because they are set in the POST request 
-    student_id: Optional[int] = Field(foreign_key="user.id")
     attempt_id: Optional[int] = Field(foreign_key="quizattempt.id")
-    quiz_id: Optional[int] = Field(foreign_key="quiz.id")
     question_id: Optional[int] = Field(foreign_key="quizquestion.id")
     time: Optional[dt.datetime] = Field(default=dt.datetime.now())
 
@@ -56,9 +54,7 @@ class QuizActionInDBBase(QuizActionBase, PKModel):
     pass
 
 class QuizAction(QuizActionInDBBase, table=True):
-    student: Optional["User"] = Relationship(back_populates="actions")
     attempt: Optional["QuizAttempt"] = Relationship(back_populates="actions")
-    quiz: Optional["Quiz"] = Relationship(back_populates="actions")
     question: Optional["QuizQuestion"] = Relationship(back_populates="actions")
 
     def __repr__(self):

--- a/inquizitor/models/quiz/action.py
+++ b/inquizitor/models/quiz/action.py
@@ -9,7 +9,8 @@ class QuizActionBase(SQLModel):
     # these fields are optional because they are set in the POST request 
     attempt_id: Optional[int] = Field(foreign_key="quizattempt.id")
     question_id: Optional[int] = Field(foreign_key="quizquestion.id")
-    time: Optional[dt.datetime] = Field(default=dt.datetime.now())
+
+    time: dt.datetime = Field(default=dt.datetime.now())
 
     blur: int = Field(default=0)
     focus: int = Field(default=0)

--- a/inquizitor/models/quiz/action.py
+++ b/inquizitor/models/quiz/action.py
@@ -3,7 +3,7 @@ import logging
 from inquizitor.db.base_class import PKModel
 from pydantic import root_validator, validator
 from sqlmodel import Field, SQLModel, Relationship
-from typing import Optional
+from typing import List, Optional
 
 class QuizActionBase(SQLModel):
     # these fields are optional because they are set in the POST request 
@@ -60,4 +60,12 @@ class QuizAction(QuizActionInDBBase, table=True):
 
     def __repr__(self):
         """Represent instance as a unique string."""
-        return f"<Action({self.student.username!r}-{self.time!r}) - blur={self.blur!r} focus={self.focus!r} copy={self.copy_!r} paste={self.paste!r} left_click={self.left_click!r} right_click={self.right_click!r} double_click={self.double_click!r}>"
+        return f"<Action({self.time!r}) - blur={self.blur!r} focus={self.focus!r} copy={self.copy_!r} paste={self.paste!r} left_click={self.left_click!r} right_click={self.right_click!r} double_click={self.double_click!r}>"
+
+class QuizActions(SQLModel):
+    student_id: int
+    student_name: str 
+    actions: List["QuizAction"]
+
+    def __repr__(self):
+        return f"<Action({self.student_id!r} - {self.student_name!r}) - {self.actions!r}>"

--- a/inquizitor/models/quiz/action.py
+++ b/inquizitor/models/quiz/action.py
@@ -16,7 +16,7 @@ class QuizActionBase(SQLModel):
     blur: int = Field(default=0)
     focus: int = Field(default=0)
     # NameError: Field name "copy" shadows a BaseModel attribute; use a different field name with "alias='copy'"
-    copy_: int = Field(alias='copy', default=0)
+    copy_: int = Field(default=0)
     paste: int = Field(default=0)
     left_click: int = Field(default=0)
     right_click: int = Field(default=0)
@@ -63,4 +63,4 @@ class QuizAction(QuizActionInDBBase, table=True):
 
     def __repr__(self):
         """Represent instance as a unique string."""
-        return f"<Action({self.time!r} - blur={self.blur!r} focus={self.focus!r}) copy={self.copy_!r} paste={self.paste!r} left_click={self.left_click!r} right_click={self.right_click!r} double_click={self.double_click!r}>"
+        return f"<Action({self.student.username!r}-{self.time!r}) - blur={self.blur!r} focus={self.focus!r} copy={self.copy_!r} paste={self.paste!r} left_click={self.left_click!r} right_click={self.right_click!r} double_click={self.double_click!r}>"

--- a/inquizitor/models/quiz/action.py
+++ b/inquizitor/models/quiz/action.py
@@ -1,0 +1,59 @@
+import datetime as dt
+import logging
+from inquizitor.db.base_class import PKModel
+from pydantic import validator
+from sqlmodel import Field, SQLModel, Relationship
+from typing import Optional
+
+class QuizActionBase(SQLModel):
+    # these fields are optional because they are set in the POST request 
+    student_id: Optional[int] = Field(foreign_key="user.id")
+    attempt_id: Optional[int] = Field(foreign_key="quizattempt.id")
+    quiz_id: Optional[int] = Field(foreign_key="quiz.id")
+    question_id: Optional[int] = Field(foreign_key="quizquestion.id")
+    time: Optional[dt.datetime] = Field(default=dt.datetime.now())
+
+    blur: int = Field(default=0)
+    focus: int = Field(default=0)
+    # NameError: Field name "copy" shadows a BaseModel attribute; use a different field name with "alias='copy'"
+    copy_: int = Field(alias='copy', default=0)
+    paste: int = Field(default=0)
+    left_click: int = Field(default=0)
+    right_click: int = Field(default=0)
+    double_click: int = Field(default=0)
+
+    # TODO
+    # @validator('blur', 'focus', 'copy_', 'paste', 'left_click', 'right_click', 'double_click')
+    # def check_has_action(cls, v, values, **kwargs):
+    #     logging.info(f"{values}\n")
+    #     if sum(values) > 1:
+    #         raise ValueError('Only a single action is allowed per record')
+    #     elif sum(values) < 1:
+    #         raise ValueError('Record must have an action/ event')
+    #     return values
+
+class QuizActionCreate(QuizActionBase):
+    pass
+
+# kept for CRUD purposes, endpoint will not be created
+class QuizActionUpdate(QuizActionBase):
+    blur: Optional[int] = Field(default=0)
+    focus: Optional[int] = Field(default=0)
+    copy_: Optional[int] = Field(default=0)
+    paste: Optional[int] = Field(default=0)
+    left_click: Optional[int] = Field(default=0)
+    right_click: Optional[int] = Field(default=0)
+    double_click: Optional[int] = Field(default=0)
+
+class QuizActionInDBBase(QuizActionBase, PKModel):
+    pass
+
+class QuizAction(QuizActionInDBBase, table=True):
+    student: Optional["User"] = Relationship(back_populates="actions")
+    attempt: Optional["QuizAttempt"] = Relationship(back_populates="actions")
+    quiz: Optional["Quiz"] = Relationship(back_populates="actions")
+    question: Optional["QuizQuestion"] = Relationship(back_populates="actions")
+
+    def __repr__(self):
+        """Represent instance as a unique string."""
+        return f"<Action({self.time!r} - blur={self.blur!r} focus={self.focus!r}) copy={self.copy_!r} paste={self.paste!r} left_click={self.left_click!r} right_click={self.right_click!r} double_click={self.double_click!r}>"

--- a/inquizitor/models/quiz/action.py
+++ b/inquizitor/models/quiz/action.py
@@ -22,17 +22,22 @@ class QuizActionBase(SQLModel):
     right_click: int = Field(default=0)
     double_click: int = Field(default=0)
 
-    # @root_validator(pre=True)
-    # def check_has_action(cls, values):
-
-    # @validator('blur', 'focus', 'copy_', 'paste', 'left_click', 'right_click', 'double_click')
-    # def check_has_action(cls, v, values, **kwargs):
-    #     logging.info(f"{values}\n")
-    #     if sum(values) > 1:
-    #         raise ValueError('Only a single action is allowed per record')
-    #     elif sum(values) < 1:
-    #         raise ValueError('Record must have an action/ event')
-    #     return values
+    @validator('double_click')
+    def check_has_action(cls, v, values, **kwargs):
+        actions = [
+            values['blur'],
+            values['focus'],
+            values['copy_'],
+            values['paste'],
+            values['left_click'],
+            values['right_click'],
+            v, # values['double_click'],
+        ]
+        if sum(actions) > 1:
+            raise Exception('Only a single action is allowed per record')
+        elif sum(actions) < 1:
+            raise Exception('Record must have an action/ event')
+        return v
 
 class QuizActionCreate(QuizActionBase):
     pass

--- a/inquizitor/models/quiz/attempt.py
+++ b/inquizitor/models/quiz/attempt.py
@@ -39,3 +39,6 @@ class QuizAttempt(QuizAttemptInDBBase, table=True):
     student: Optional[User] = Relationship(back_populates="attempts")
     quiz: Optional[Quiz] = Relationship(back_populates="attempts")
     answers: Optional["QuizAnswer"] = Relationship(back_populates="attempt")
+    actions: Optional["QuizAction"] = Relationship(
+        back_populates="attempt", sa_relationship_kwargs={"cascade": "delete"}
+    )

--- a/inquizitor/models/quiz/question.py
+++ b/inquizitor/models/quiz/question.py
@@ -30,6 +30,9 @@ class QuizQuestion(QuizQuestionInDBBase, table=True):
     )
     attempts: List["QuizAttempt"] = Relationship(back_populates="recent_question")
     quiz: Optional["Quiz"] = Relationship(back_populates="questions")
+    actions: Optional["QuizAction"] = Relationship(
+        back_populates="question", sa_relationship_kwargs={"cascade": "delete"}
+    )
 
     def __repr__(self):
         return f"<Question({self.content!r})>"

--- a/inquizitor/models/quiz/quiz.py
+++ b/inquizitor/models/quiz/quiz.py
@@ -52,6 +52,9 @@ class Quiz(QuizInDBBase, table=True):
     questions: List["QuizQuestion"] = Relationship(
         back_populates="quiz", sa_relationship_kwargs={"cascade": "delete"}
     )
+    actions: Optional["QuizAction"] = Relationship(
+        back_populates="quiz", sa_relationship_kwargs={"cascade": "delete"}
+    )
 
     def __repr__(self):
         """Represent instance as a unique string."""

--- a/inquizitor/models/quiz/quiz.py
+++ b/inquizitor/models/quiz/quiz.py
@@ -52,9 +52,6 @@ class Quiz(QuizInDBBase, table=True):
     questions: List["QuizQuestion"] = Relationship(
         back_populates="quiz", sa_relationship_kwargs={"cascade": "delete"}
     )
-    actions: Optional["QuizAction"] = Relationship(
-        back_populates="quiz", sa_relationship_kwargs={"cascade": "delete"}
-    )
 
     def __repr__(self):
         """Represent instance as a unique string."""

--- a/inquizitor/models/user.py
+++ b/inquizitor/models/user.py
@@ -54,10 +54,13 @@ class User(UserInDBBase, table=True):
     teacher_quizzes: List["Quiz"] = Relationship(back_populates="teacher")
 
     # for student
+    student_quizzes: List[QuizStudentLink] = Relationship(back_populates="student")
     attempts: List["QuizAttempt"] = Relationship(back_populates="student")
     answers: List["QuizAnswer"] = Relationship(back_populates="student")
 
-    student_quizzes: List[QuizStudentLink] = Relationship(back_populates="student")
+    actions: Optional["QuizAction"] = Relationship(
+        back_populates="student", sa_relationship_kwargs={"cascade": "delete"}
+    )
 
     def __repr__(self):
         """Represent instance as a unique string."""

--- a/inquizitor/models/user.py
+++ b/inquizitor/models/user.py
@@ -58,10 +58,6 @@ class User(UserInDBBase, table=True):
     attempts: List["QuizAttempt"] = Relationship(back_populates="student")
     answers: List["QuizAnswer"] = Relationship(back_populates="student")
 
-    actions: Optional["QuizAction"] = Relationship(
-        back_populates="student", sa_relationship_kwargs={"cascade": "delete"}
-    )
-
     def __repr__(self):
         """Represent instance as a unique string."""
         return f"<User({self.email!r})>"

--- a/inquizitor/tests/api/api_v1/test_actions.py
+++ b/inquizitor/tests/api/api_v1/test_actions.py
@@ -1,71 +1,82 @@
-# import datetime as dt
+import datetime as dt
 import logging
 import pytest
-# from httpx import AsyncClient
-# from pprint import pformat
-# from sqlmodel import Session
-# from typing import Dict
+from httpx import AsyncClient
+from sqlmodel import Session
+from typing import Dict
 
-# from fastapi.encoders import jsonable_encoder
-
-# from inquizitor import crud
-# from inquizitor.tests.factories import QuestionFactory, QuizFactory
+from inquizitor import crud
+from inquizitor.tests.factories import ActionFactory, AttemptFactory, QuestionFactory
 
 logging.basicConfig(level=logging.INFO)
 
-# DT_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+DT_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
-# @pytest.mark.anyio
-# class TestCreateQuiz:
-#     async def test_create_quiz_superuser(
-#         self, db: Session, client: AsyncClient, superuser_cookies: Dict[str, str]
-#     ) -> None:
-#         superuser_cookies = await superuser_cookies
-#         r = await client.get("/users/profile", cookies=superuser_cookies)
-#         result = r.json()
-#         user = crud.user.get(db, id=result["id"])
-#         quiz_in = QuizFactory.stub(schema_type="create", teacher=user)
-#         r = await client.post(f"/quizzes/", cookies=superuser_cookies, json=quiz_in)
-#         result = r.json()
-#         assert r.status_code == 200
-#         assert result["name"] == quiz_in["name"]
-#         assert result["desc"] == quiz_in["desc"]
-#         assert result["number_of_questions"] == quiz_in["number_of_questions"]
-#         assert result["created_at"] == quiz_in["created_at"]
-#         assert result["due_date"] == quiz_in["due_date"]
-#         assert result["quiz_code"]
-#         assert result["teacher_id"] == quiz_in["teacher_id"]
+@pytest.mark.anyio
+class TestCreateAction:
+    async def test_create_action_superuser(
+        self, db: Session, client: AsyncClient, superuser_cookies: Dict[str, str]
+    ) -> None:
+        superuser_cookies = await superuser_cookies
+        r = await client.get("/users/profile", cookies=superuser_cookies)
+        result = r.json()
+        user = crud.user.get(db, id=result["id"])
+        attempt = AttemptFactory()
+        question = QuestionFactory(quiz_id=attempt.quiz_id)
+        action_in = ActionFactory.stub(schema_type="create", attempt=attempt, question=question)
+        r = await client.post(
+            f"/quizzes/{attempt.quiz_id}/questions/{question.id}/actions", 
+            cookies=superuser_cookies, 
+            json=action_in
+        )
+        result = r.json()
+        assert r.status_code == 400
 
-    # async def test_create_quiz_teacher(
-    #     self, db: Session, client: AsyncClient, teacher_cookies: Dict[str, str]
-    # ) -> None:
-    #     teacher_cookies = await teacher_cookies
-    #     r = await client.get("/users/profile", cookies=teacher_cookies)
-    #     result = r.json()
-    #     user = crud.user.get(db, id=result["id"])
-    #     quiz_in = QuizFactory.stub(schema_type="create", teacher=user)
-    #     r = await client.post(f"/quizzes/", cookies=teacher_cookies, json=quiz_in)
-    #     result = r.json()
-    #     assert r.status_code == 200
-    #     assert result["name"] == quiz_in["name"]
-    #     assert result["desc"] == quiz_in["desc"]
-    #     assert result["number_of_questions"] == quiz_in["number_of_questions"]
-    #     assert result["created_at"] == quiz_in["created_at"]
-    #     assert result["due_date"] == quiz_in["due_date"]
-    #     # assert result["quiz_code"]
-    #     assert result["teacher_id"] == quiz_in["teacher_id"]
+    async def test_create_action_teacher(
+        self, db: Session, client: AsyncClient, teacher_cookies: Dict[str, str]
+    ) -> None:
+        teacher_cookies = await teacher_cookies
+        r = await client.get("/users/profile", cookies=teacher_cookies)
+        result = r.json()
+        user = crud.user.get(db, id=result["id"])
+        attempt = AttemptFactory()
+        question = QuestionFactory(quiz_id=attempt.quiz_id)
+        action_in = ActionFactory.stub(schema_type="create", attempt=attempt, question=question)
+        r = await client.post(
+            f"/quizzes/{attempt.quiz_id}/questions/{question.id}/actions", 
+            cookies=teacher_cookies, 
+            json=action_in
+        )
+        result = r.json()
+        assert r.status_code == 400
 
-    # async def test_create_quiz_student(
-    #     self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
-    # ) -> None:
-    #     student_cookies = await student_cookies
-    #     r = await client.get("/users/profile", cookies=student_cookies)
-    #     result = r.json()
-    #     student = crud.user.get(db, id=result["id"])
-    #     quiz_in = QuizFactory.stub(schema_type="create", teacher=student)
-    #     r = await client.post(f"/quizzes/", cookies=student_cookies, json=quiz_in)
-    #     result = r.json()
-    #     assert r.status_code == 400
+    async def test_create_action_student(
+        self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
+    ) -> None:
+        student_cookies = await student_cookies
+        r = await client.get("/users/profile", cookies=student_cookies)
+        result = r.json()
+        user = crud.user.get(db, id=result["id"])
+        attempt = AttemptFactory(student=user)
+        question = QuestionFactory(quiz_id=attempt.quiz_id)
+        action_in = ActionFactory.stub(schema_type="create", attempt=attempt, question=question)
+        r = await client.post(
+            f"/quizzes/{attempt.quiz_id}/questions/{question.id}/actions", 
+            cookies=student_cookies, 
+            json=action_in
+        )
+        result = r.json()
+        assert r.status_code == 200
+        # assert result["time"] == dt.datetime.strftime(quiz.time, DT_FORMAT)
+        assert result["time"] == action_in["time"]
+        assert result["blur"] == action_in["blur"]
+        assert result["focus"] == action_in["focus"]
+        assert result["copy_"] == action_in["copy_"]
+        assert result["paste"] == action_in["paste"]
+        assert result["left_click"] == action_in["left_click"]
+        assert result["right_click"] == action_in["right_click"]
+        assert result["double_click"] == action_in["double_click"]
+
 
 
 # @pytest.mark.anyio

--- a/inquizitor/tests/api/api_v1/test_actions.py
+++ b/inquizitor/tests/api/api_v1/test_actions.py
@@ -2,15 +2,17 @@ import datetime as dt
 import logging
 import pytest
 from httpx import AsyncClient
+from pprint import pformat
 from sqlmodel import Session
 from typing import Dict
+from fastapi.encoders import jsonable_encoder
 
 from inquizitor import crud
-from inquizitor.tests.factories import ActionFactory, AttemptFactory, QuestionFactory
-
+from inquizitor.models import QuizActions
+from inquizitor.tests.factories import (
+    ActionFactory, AttemptFactory, QuestionFactory, QuizFactory, UserFactory
+)
 logging.basicConfig(level=logging.INFO)
-
-DT_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
 @pytest.mark.anyio
 class TestCreateAction:
@@ -67,7 +69,6 @@ class TestCreateAction:
         )
         result = r.json()
         assert r.status_code == 200
-        # assert result["time"] == dt.datetime.strftime(quiz.time, DT_FORMAT)
         assert result["time"] == action_in["time"]
         assert result["blur"] == action_in["blur"]
         assert result["focus"] == action_in["focus"]
@@ -79,42 +80,79 @@ class TestCreateAction:
 
 
 
-# @pytest.mark.anyio
-# class TestReadQuestion:
-#     async def test_read_question_student(
-#         self, client: AsyncClient, student_cookies: Dict[str, str]
-#     ) -> None:
-#         question = QuestionFactory()
-#         r = await client.get(
-#             f"/quizzes/{question.quiz_id}/questions/{question.id}",
-#             cookies=await student_cookies,
-#         )
-#         result = r.json()
-#         assert r.status_code == 200
-#         assert result["id"] == question.id
-#         assert result["content"] == question.content
-#         assert result["points"] == question.points
-#         assert result["order"] == question.order
-#         assert result["quiz_id"] == question.quiz_id
+@pytest.mark.anyio
+class TestReadQuestionActions:
+    async def test_read_question_actions_students(
+        self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
+    ) -> None:
+        student_cookies = await student_cookies
+        PASSWORD = "test"
+        question_actions = []
+        quiz = QuizFactory()
+        question = QuestionFactory(quiz=quiz)
+        for i in range(3): # three students
+            student = UserFactory(student=True, password=PASSWORD)
+            user = crud.user.get(db, id=student.id)
+            attempt = AttemptFactory(quiz=quiz, student=user)
+            actions = []
+            for j in range(5): # five question actions each
+                action_in = ActionFactory.stub(schema_type="create", attempt=attempt, question=question)
+                action = crud.quiz_action.create(db, obj_in=action_in)
+                actions.append(action_in)
+            question_actions.append(
+                {"student_id":user.id, "student_name":user.full_name, "actions":actions}
+            )
 
-#     async def test_read_question_teacher(
-#         self, client: AsyncClient, teacher_cookies: Dict[str, str]
-#     ) -> None:
-#         question = QuestionFactory()
-#         r = await client.get(
-#             f"/quizzes/{question.quiz_id}/questions/{question.id}",
-#             cookies=await teacher_cookies,
-#         )
-#         result = r.json()
-#         assert r.status_code == 200
-#         assert result["id"] == question.id
-#         assert result["content"] == question.content
-#         assert result["points"] == question.points
-#         assert result["order"] == question.order
-#         assert result["quiz_id"] == question.quiz_id
+        r = await client.get(
+            f"/quizzes/{question.quiz_id}/questions/{question.id}/actions",
+            cookies=student_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 400
 
-#     async def test_read_question_superuser(
-#         self, client: AsyncClient, superuser_cookies: Dict[str, str]
+    async def test_read_question_actions_teacher(
+        self, db:Session, client: AsyncClient, teacher_cookies: Dict[str, str]
+    ) -> None:
+        PASSWORD = "test"
+        teacher_cookies = await teacher_cookies
+        r = await client.get("/users/profile", cookies=teacher_cookies)
+        result = r.json()
+        teacher = crud.user.get(db, id=result["id"])
+        quiz = QuizFactory(teacher=teacher)
+        question = QuestionFactory(quiz=quiz)
+
+        question_actions = []
+        for i in range(3): # three students
+            student = UserFactory(student=True, password=PASSWORD)
+            user = crud.user.get(db, id=student.id)
+            attempt = AttemptFactory(quiz=quiz, student=user)
+            actions = []
+            for j in range(5): # five question actions each
+                action = ActionFactory(attempt=attempt, question=question)
+                action = jsonable_encoder(crud.quiz_action.get(db, id=action.id))
+                actions.append(action)
+            question_actions.append(
+                {"actions":actions, "student_id":user.id, "student_name":user.full_name}
+            )
+
+        r = await client.get(
+            f"/quizzes/{question.quiz_id}/questions/{question.id}/actions",
+            cookies=teacher_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 200
+        student_ids = [student["student_id"] for student in question_actions]
+        student_names = [student["student_name"] for student in question_actions]
+        actions = {student["student_id"]: student["actions"] for student in question_actions}
+        for student_in_db in result:
+            assert student_in_db["student_id"] in student_ids
+            assert student_in_db["student_name"] in student_names
+            for action_in_db in student_in_db["actions"]:
+                logging.info(f"{pformat(action_in_db)} IN {pformat(actions[student_in_db['student_id']])}")
+                assert action_in_db in actions[student_in_db["student_id"]]
+
+#     async def test_read_question_actions_superuser(
+#         self, db:Session, client: AsyncClient, superuser_cookies: Dict[str, str]
 #     ) -> None:
 #         question = QuestionFactory()
 #         r = await client.get(
@@ -130,8 +168,8 @@ class TestCreateAction:
 #         assert result["quiz_id"] == question.quiz_id
 
 #     # NOTE supposedly on crud tests but seems therell be no crud tests
-#     async def test_read_question_does_not_belong_to_quiz(
-#         self, client: AsyncClient, superuser_cookies: Dict[str, str]
+#     async def test_read_question_actions_does_not_belong_to_quiz(
+#         self, db: Session, client: AsyncClient, superuser_cookies: Dict[str, str]
 #     ) -> None:
 #         quiz = QuizFactory()
 #         question = QuestionFactory()

--- a/inquizitor/tests/api/api_v1/test_actions.py
+++ b/inquizitor/tests/api/api_v1/test_actions.py
@@ -78,31 +78,28 @@ class TestCreateAction:
         assert result["right_click"] == action_in["right_click"]
         assert result["double_click"] == action_in["double_click"]
 
-
-
 @pytest.mark.anyio
 class TestReadQuestionActions:
     async def test_read_question_actions_students(
         self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
     ) -> None:
-        student_cookies = await student_cookies
-        PASSWORD = "test"
         question_actions = []
         quiz = QuizFactory()
         question = QuestionFactory(quiz=quiz)
         for i in range(3): # three students
-            student = UserFactory(student=True, password=PASSWORD)
+            student = UserFactory(student=True)
             user = crud.user.get(db, id=student.id)
             attempt = AttemptFactory(quiz=quiz, student=user)
             actions = []
             for j in range(5): # five question actions each
-                action_in = ActionFactory.stub(schema_type="create", attempt=attempt, question=question)
-                action = crud.quiz_action.create(db, obj_in=action_in)
-                actions.append(action_in)
+                action = ActionFactory(attempt=attempt, question=question)
+                action = jsonable_encoder(crud.quiz_action.get(db, id=action.id))
+                actions.append(action)
             question_actions.append(
                 {"student_id":user.id, "student_name":user.full_name, "actions":actions}
             )
 
+        student_cookies = await student_cookies
         r = await client.get(
             f"/quizzes/{question.quiz_id}/questions/{question.id}/actions",
             cookies=student_cookies,
@@ -110,11 +107,11 @@ class TestReadQuestionActions:
         result = r.json()
         assert r.status_code == 400
 
-    async def test_read_question_actions_teacher(
-        self, db:Session, client: AsyncClient, teacher_cookies: Dict[str, str]
+    async def test_read_question_actions_teacher_superuser(
+        self, db:Session, client: AsyncClient, teacher_cookies: Dict[str, str], superuser_cookies: Dict[str, str] 
     ) -> None:
-        PASSWORD = "test"
         teacher_cookies = await teacher_cookies
+        superuser_cookies = await superuser_cookies
         r = await client.get("/users/profile", cookies=teacher_cookies)
         result = r.json()
         teacher = crud.user.get(db, id=result["id"])
@@ -123,7 +120,7 @@ class TestReadQuestionActions:
 
         question_actions = []
         for i in range(3): # three students
-            student = UserFactory(student=True, password=PASSWORD)
+            student = UserFactory(student=True)
             user = crud.user.get(db, id=student.id)
             attempt = AttemptFactory(quiz=quiz, student=user)
             actions = []
@@ -148,34 +145,227 @@ class TestReadQuestionActions:
             assert student_in_db["student_id"] in student_ids
             assert student_in_db["student_name"] in student_names
             for action_in_db in student_in_db["actions"]:
-                logging.info(f"{pformat(action_in_db)} IN {pformat(actions[student_in_db['student_id']])}")
                 assert action_in_db in actions[student_in_db["student_id"]]
 
-#     async def test_read_question_actions_superuser(
-#         self, db:Session, client: AsyncClient, superuser_cookies: Dict[str, str]
-#     ) -> None:
-#         question = QuestionFactory()
-#         r = await client.get(
-#             f"/quizzes/{question.quiz_id}/questions/{question.id}",
-#             cookies=await superuser_cookies,
-#         )
-#         result = r.json()
-#         assert r.status_code == 200
-#         assert result["id"] == question.id
-#         assert result["content"] == question.content
-#         assert result["points"] == question.points
-#         assert result["order"] == question.order
-#         assert result["quiz_id"] == question.quiz_id
+        r = await client.get(
+            f"/quizzes/{question.quiz_id}/questions/{question.id}/actions",
+            cookies=superuser_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 200
+        for student_in_db in result:
+            assert student_in_db["student_id"] in student_ids
+            assert student_in_db["student_name"] in student_names
+            for action_in_db in student_in_db["actions"]:
+                assert action_in_db in actions[student_in_db["student_id"]]
 
-#     # NOTE supposedly on crud tests but seems therell be no crud tests
-#     async def test_read_question_actions_does_not_belong_to_quiz(
-#         self, db: Session, client: AsyncClient, superuser_cookies: Dict[str, str]
-#     ) -> None:
-#         quiz = QuizFactory()
-#         question = QuestionFactory()
-#         r = await client.get(
-#             f"/quizzes/{quiz.id}/questions/{question.id}",
-#             cookies=await superuser_cookies,
-#         )
-#         result = r.json()
-#         assert r.status_code == 404
+@pytest.mark.anyio
+class TestReadQuizActions:
+    async def test_read_quiz_actions_students(
+        self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
+    ) -> None:
+        quiz_actions = []
+        quiz = QuizFactory()
+        questions = [QuestionFactory(quiz=quiz) for i in range(3)]
+        for i in range(3): # three students
+            student = UserFactory(student=True)
+            user = crud.user.get(db, id=student.id)
+            attempt = AttemptFactory(quiz=quiz, student=user)
+            actions = []
+            for q in questions:
+                for j in range(3): # three actions each
+                    action = ActionFactory(attempt=attempt, question=q)
+                    action = jsonable_encoder(crud.quiz_action.get(db, id=action.id))
+                    actions.append(action)
+                quiz_actions.append(
+                    {"student_id":user.id, "student_name":user.full_name, "actions":actions}
+                )
+
+        student_cookies = await student_cookies
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/actions",
+            cookies=student_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 400
+
+    async def test_read_quiz_actions_teacher_superuser(
+        self, db:Session, client: AsyncClient, teacher_cookies: Dict[str, str], superuser_cookies: Dict[str, str] 
+    ) -> None:
+        teacher_cookies = await teacher_cookies
+        superuser_cookies = await superuser_cookies
+        r = await client.get("/users/profile", cookies=teacher_cookies)
+        result = r.json()
+        teacher = crud.user.get(db, id=result["id"])
+        quiz = QuizFactory(teacher=teacher)
+        questions = [QuestionFactory(quiz=quiz) for i in range(3)]
+
+        quiz_actions = []
+        for i in range(3): # three students
+            student = UserFactory(student=True)
+            user = crud.user.get(db, id=student.id)
+            attempt = AttemptFactory(quiz=quiz, student=user)
+            actions = []
+            for q in questions:
+                for j in range(3): # three actions each
+                    action = ActionFactory(attempt=attempt, question=q)
+                    action = jsonable_encoder(crud.quiz_action.get(db, id=action.id))
+                    actions.append(action)
+                quiz_actions.append(
+                    {"student_id":user.id, "student_name":user.full_name, "actions":actions}
+                )
+
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/actions",
+            cookies=teacher_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 200
+        student_ids = [student["student_id"] for student in quiz_actions]
+        student_names = [student["student_name"] for student in quiz_actions]
+        actions = {student["student_id"]: student["actions"] for student in quiz_actions}
+        for student_in_db in result:
+            assert student_in_db["student_id"] in student_ids
+            assert student_in_db["student_name"] in student_names
+            for action_in_db in student_in_db["actions"]:
+                assert action_in_db in actions[student_in_db["student_id"]]
+
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/actions",
+            cookies=superuser_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 200
+        for student_in_db in result:
+            assert student_in_db["student_id"] in student_ids
+            assert student_in_db["student_name"] in student_names
+            for action_in_db in student_in_db["actions"]:
+                assert action_in_db in actions[student_in_db["student_id"]]
+
+@pytest.mark.anyio
+class TestReadAttemptActions:
+    async def test_read_attempt_actions_students(
+        self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
+    ) -> None:
+        quiz = QuizFactory()
+        questions = [QuestionFactory(quiz=quiz) for i in range(3)]
+        student = UserFactory(student=True)
+        user = crud.user.get(db, id=student.id)
+        attempt = AttemptFactory(quiz=quiz, student=user)
+
+        actions = []
+        for q in questions:
+            for j in range(3): # three actions each
+                action = ActionFactory(attempt=attempt, question=q)
+                action = jsonable_encoder(crud.quiz_action.get(db, id=action.id))
+                actions.append(action)
+
+        student_cookies = await student_cookies
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/{student.id}/actions",
+            cookies=student_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 400
+
+    async def test_read_attempt_actions_teacher_superuser(
+        self, db:Session, client: AsyncClient, teacher_cookies: Dict[str, str], superuser_cookies: Dict[str, str] 
+    ) -> None:
+        teacher_cookies = await teacher_cookies
+        superuser_cookies = await superuser_cookies
+        r = await client.get("/users/profile", cookies=teacher_cookies)
+        result = r.json()
+        teacher = crud.user.get(db, id=result["id"])
+
+        quiz = QuizFactory(teacher=teacher)
+        questions = [QuestionFactory(quiz=quiz) for i in range(3)]
+        student = UserFactory(student=True)
+        attempt = AttemptFactory(quiz=quiz, student=student)
+
+        actions = []
+        for q in questions:
+            for j in range(3): # three actions each
+                action = ActionFactory(attempt=attempt, question=q)
+                action = jsonable_encoder(crud.quiz_action.get(db, id=action.id))
+                actions.append(action)
+
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/{student.id}/actions",
+            cookies=teacher_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 200
+        for action_in_db in result:
+            assert action_in_db in actions
+
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/{student.id}/actions",
+            cookies=superuser_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 200
+        for action_in_db in result:
+            assert action_in_db in actions
+
+@pytest.mark.anyio
+class TestReadAttemptQuestionActions:
+    async def test_read_attempt_question_actions_students(
+        self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
+    ) -> None:
+        quiz = QuizFactory()
+        question = QuestionFactory(quiz=quiz)
+        student = UserFactory(student=True)
+        user = crud.user.get(db, id=student.id)
+        attempt = AttemptFactory(quiz=quiz, student=user)
+
+        actions = []
+        for j in range(3):
+            action = ActionFactory(attempt=attempt, question=question)
+            action = jsonable_encoder(crud.quiz_action.get(db, id=action.id))
+            actions.append(action)
+
+        student_cookies = await student_cookies
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/questions/{question.id}/{student.id}/actions",
+            cookies=student_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 400
+
+    async def test_read_attempt_question_actions_teacher_superuser(
+        self, db:Session, client: AsyncClient, teacher_cookies: Dict[str, str], superuser_cookies: Dict[str, str] 
+    ) -> None:
+        teacher_cookies = await teacher_cookies
+        superuser_cookies = await superuser_cookies
+        r = await client.get("/users/profile", cookies=teacher_cookies)
+        result = r.json()
+        teacher = crud.user.get(db, id=result["id"])
+
+        quiz = QuizFactory(teacher=teacher)
+        question = QuestionFactory(quiz=quiz)
+        student = UserFactory(student=True)
+        attempt = AttemptFactory(quiz=quiz, student=student)
+
+        actions = []
+        for j in range(3):
+            action = ActionFactory(attempt=attempt, question=question)
+            action = jsonable_encoder(crud.quiz_action.get(db, id=action.id))
+            actions.append(action)
+
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/questions/{question.id}/{student.id}/actions",
+            cookies=teacher_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 200
+        for action_in_db in result:
+            assert action_in_db in actions
+
+        r = await client.get(
+            f"/quizzes/{quiz.quiz_code}/questions/{question.id}/{student.id}/actions",
+            cookies=superuser_cookies,
+        )
+        result = r.json()
+        assert r.status_code == 200
+        for action_in_db in result:
+            assert action_in_db in actions

--- a/inquizitor/tests/api/api_v1/test_actions.py
+++ b/inquizitor/tests/api/api_v1/test_actions.py
@@ -1,0 +1,132 @@
+# import datetime as dt
+import logging
+import pytest
+# from httpx import AsyncClient
+# from pprint import pformat
+# from sqlmodel import Session
+# from typing import Dict
+
+# from fastapi.encoders import jsonable_encoder
+
+# from inquizitor import crud
+# from inquizitor.tests.factories import QuestionFactory, QuizFactory
+
+logging.basicConfig(level=logging.INFO)
+
+# DT_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+
+# @pytest.mark.anyio
+# class TestCreateQuiz:
+#     async def test_create_quiz_superuser(
+#         self, db: Session, client: AsyncClient, superuser_cookies: Dict[str, str]
+#     ) -> None:
+#         superuser_cookies = await superuser_cookies
+#         r = await client.get("/users/profile", cookies=superuser_cookies)
+#         result = r.json()
+#         user = crud.user.get(db, id=result["id"])
+#         quiz_in = QuizFactory.stub(schema_type="create", teacher=user)
+#         r = await client.post(f"/quizzes/", cookies=superuser_cookies, json=quiz_in)
+#         result = r.json()
+#         assert r.status_code == 200
+#         assert result["name"] == quiz_in["name"]
+#         assert result["desc"] == quiz_in["desc"]
+#         assert result["number_of_questions"] == quiz_in["number_of_questions"]
+#         assert result["created_at"] == quiz_in["created_at"]
+#         assert result["due_date"] == quiz_in["due_date"]
+#         assert result["quiz_code"]
+#         assert result["teacher_id"] == quiz_in["teacher_id"]
+
+    # async def test_create_quiz_teacher(
+    #     self, db: Session, client: AsyncClient, teacher_cookies: Dict[str, str]
+    # ) -> None:
+    #     teacher_cookies = await teacher_cookies
+    #     r = await client.get("/users/profile", cookies=teacher_cookies)
+    #     result = r.json()
+    #     user = crud.user.get(db, id=result["id"])
+    #     quiz_in = QuizFactory.stub(schema_type="create", teacher=user)
+    #     r = await client.post(f"/quizzes/", cookies=teacher_cookies, json=quiz_in)
+    #     result = r.json()
+    #     assert r.status_code == 200
+    #     assert result["name"] == quiz_in["name"]
+    #     assert result["desc"] == quiz_in["desc"]
+    #     assert result["number_of_questions"] == quiz_in["number_of_questions"]
+    #     assert result["created_at"] == quiz_in["created_at"]
+    #     assert result["due_date"] == quiz_in["due_date"]
+    #     # assert result["quiz_code"]
+    #     assert result["teacher_id"] == quiz_in["teacher_id"]
+
+    # async def test_create_quiz_student(
+    #     self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
+    # ) -> None:
+    #     student_cookies = await student_cookies
+    #     r = await client.get("/users/profile", cookies=student_cookies)
+    #     result = r.json()
+    #     student = crud.user.get(db, id=result["id"])
+    #     quiz_in = QuizFactory.stub(schema_type="create", teacher=student)
+    #     r = await client.post(f"/quizzes/", cookies=student_cookies, json=quiz_in)
+    #     result = r.json()
+    #     assert r.status_code == 400
+
+
+# @pytest.mark.anyio
+# class TestReadQuestion:
+#     async def test_read_question_student(
+#         self, client: AsyncClient, student_cookies: Dict[str, str]
+#     ) -> None:
+#         question = QuestionFactory()
+#         r = await client.get(
+#             f"/quizzes/{question.quiz_id}/questions/{question.id}",
+#             cookies=await student_cookies,
+#         )
+#         result = r.json()
+#         assert r.status_code == 200
+#         assert result["id"] == question.id
+#         assert result["content"] == question.content
+#         assert result["points"] == question.points
+#         assert result["order"] == question.order
+#         assert result["quiz_id"] == question.quiz_id
+
+#     async def test_read_question_teacher(
+#         self, client: AsyncClient, teacher_cookies: Dict[str, str]
+#     ) -> None:
+#         question = QuestionFactory()
+#         r = await client.get(
+#             f"/quizzes/{question.quiz_id}/questions/{question.id}",
+#             cookies=await teacher_cookies,
+#         )
+#         result = r.json()
+#         assert r.status_code == 200
+#         assert result["id"] == question.id
+#         assert result["content"] == question.content
+#         assert result["points"] == question.points
+#         assert result["order"] == question.order
+#         assert result["quiz_id"] == question.quiz_id
+
+#     async def test_read_question_superuser(
+#         self, client: AsyncClient, superuser_cookies: Dict[str, str]
+#     ) -> None:
+#         question = QuestionFactory()
+#         r = await client.get(
+#             f"/quizzes/{question.quiz_id}/questions/{question.id}",
+#             cookies=await superuser_cookies,
+#         )
+#         result = r.json()
+#         assert r.status_code == 200
+#         assert result["id"] == question.id
+#         assert result["content"] == question.content
+#         assert result["points"] == question.points
+#         assert result["order"] == question.order
+#         assert result["quiz_id"] == question.quiz_id
+
+#     # NOTE supposedly on crud tests but seems therell be no crud tests
+#     async def test_read_question_does_not_belong_to_quiz(
+#         self, client: AsyncClient, superuser_cookies: Dict[str, str]
+#     ) -> None:
+#         quiz = QuizFactory()
+#         question = QuestionFactory()
+#         r = await client.get(
+#             f"/quizzes/{quiz.id}/questions/{question.id}",
+#             cookies=await superuser_cookies,
+#         )
+#         result = r.json()
+#         assert r.status_code == 404

--- a/inquizitor/tests/api/api_v1/test_questions.py
+++ b/inquizitor/tests/api/api_v1/test_questions.py
@@ -24,10 +24,11 @@ class TestCreateQuestions:
         r = await client.get("/users/profile", cookies=superuser_cookies)
         result = r.json()
         user = crud.user.get(db, id=result["id"])
-        quiz = QuizFactory(teacher=user)
+        quiz = QuizFactory(teacher=user, quiz_code=crud.quiz.generate_code(db))
         question_in = QuestionFactory.stub(schema_type="create", quiz=quiz)
         r = await client.post(f"/quizzes/{quiz.quiz_code}/questions", cookies=superuser_cookies, json=question_in)
         result = r.json()
+        logging.info(f"RES: {pformat(result)}")
         assert r.status_code == 200
         assert result["content"] == question_in["content"]
         assert result["points"] == question_in["points"]
@@ -42,10 +43,11 @@ class TestCreateQuestions:
         r = await client.get("/users/profile", cookies=teacher_cookies)
         result = r.json()
         user = crud.user.get(db, id=result["id"])
-        quiz = QuizFactory(teacher=user)
+        quiz = QuizFactory(teacher=user, quiz_code=crud.quiz.generate_code(db))
         question_in = QuestionFactory.stub(schema_type="create", quiz=quiz)
         r = await client.post(f"/quizzes/{quiz.quiz_code}/questions", cookies=teacher_cookies, json=question_in)
         result = r.json()
+        logging.info(f"RES: {pformat(result)}")
         assert r.status_code == 200
         assert result["content"] == question_in["content"]
         assert result["points"] == question_in["points"]
@@ -60,10 +62,11 @@ class TestCreateQuestions:
         r = await client.get("/users/profile", cookies=student_cookies)
         result = r.json()
         user = crud.user.get(db, id=result["id"])
-        quiz = QuizFactory(teacher=user)
+        quiz = QuizFactory(teacher=user, quiz_code=crud.quiz.generate_code(db))
         question_in = QuestionFactory.stub(schema_type="create", quiz=quiz)
         r = await client.post(f"/quizzes/{quiz.quiz_code}/questions", cookies=student_cookies, json=question_in)
         result = r.json()
+        logging.info(f"RES: {pformat(result)}")
         assert r.status_code == 400
 
 @pytest.mark.anyio

--- a/inquizitor/tests/api/api_v1/test_questions.py
+++ b/inquizitor/tests/api/api_v1/test_questions.py
@@ -15,6 +15,56 @@ logging.basicConfig(level=logging.INFO)
 
 DT_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
+@pytest.mark.anyio
+class TestCreateQuestions:
+    async def test_create_question_superuser(
+        self, db: Session, client: AsyncClient, superuser_cookies: Dict[str, str]
+    ) -> None:
+        superuser_cookies = await superuser_cookies
+        r = await client.get("/users/profile", cookies=superuser_cookies)
+        result = r.json()
+        user = crud.user.get(db, id=result["id"])
+        quiz = QuizFactory(teacher=user)
+        question_in = QuestionFactory.stub(schema_type="create", quiz=quiz)
+        r = await client.post(f"/quizzes/{quiz.quiz_code}/questions", cookies=superuser_cookies, json=question_in)
+        result = r.json()
+        assert r.status_code == 200
+        assert result["content"] == question_in["content"]
+        assert result["points"] == question_in["points"]
+        assert result["order"] == question_in["order"]
+        assert result["quiz_id"] == question_in["quiz_id"]
+        assert result["question_type"] == question_in["question_type"]
+
+    async def test_create_question_teacher(
+        self, db: Session, client: AsyncClient, teacher_cookies: Dict[str, str]
+    ) -> None:
+        teacher_cookies = await teacher_cookies
+        r = await client.get("/users/profile", cookies=teacher_cookies)
+        result = r.json()
+        user = crud.user.get(db, id=result["id"])
+        quiz = QuizFactory(teacher=user)
+        question_in = QuestionFactory.stub(schema_type="create", quiz=quiz)
+        r = await client.post(f"/quizzes/{quiz.quiz_code}/questions", cookies=teacher_cookies, json=question_in)
+        result = r.json()
+        assert r.status_code == 200
+        assert result["content"] == question_in["content"]
+        assert result["points"] == question_in["points"]
+        assert result["order"] == question_in["order"]
+        assert result["quiz_id"] == question_in["quiz_id"]
+        assert result["question_type"] == question_in["question_type"]
+
+    async def test_create_question_student(
+        self, db: Session, client: AsyncClient, student_cookies: Dict[str, str]
+    ) -> None:
+        student_cookies = await student_cookies
+        r = await client.get("/users/profile", cookies=student_cookies)
+        result = r.json()
+        user = crud.user.get(db, id=result["id"])
+        quiz = QuizFactory(teacher=user)
+        question_in = QuestionFactory.stub(schema_type="create", quiz=quiz)
+        r = await client.post(f"/quizzes/{quiz.quiz_code}/questions", cookies=student_cookies, json=question_in)
+        result = r.json()
+        assert r.status_code == 400
 
 @pytest.mark.anyio
 class TestReadQuestion:

--- a/inquizitor/tests/api/api_v1/test_quizzes.py
+++ b/inquizitor/tests/api/api_v1/test_quizzes.py
@@ -22,8 +22,8 @@ class TestReadQuizzes:
     async def test_read_quizzes_superuser(
         self, db: Session, client: AsyncClient, superuser_cookies: Dict[str, str]
     ) -> None:
-        quiz = QuizFactory(quiz_code=crud.quiz.generate_code(db))
-        r = await client.get("/quizzes/", cookies=await superuser_cookies)
+        quiz = QuizFactory()
+        r = await client.get("/quizzes/?limit=400", cookies=await superuser_cookies)
         result = r.json()
         assert r.status_code == 200
         # NOTE tests use asyncio and trio (each test function is called twice)
@@ -45,7 +45,6 @@ class TestReadQuizzes:
         result = r.json()
         teacher = crud.user.get(db, id=result["id"])
         quiz = QuizFactory(teacher=teacher)
-        question = QuestionFactory(quiz=quiz)
         r = await client.get("/quizzes/", cookies=teacher_cookies)
         result = r.json()
         assert r.status_code == 200

--- a/inquizitor/tests/api/api_v1/test_quizzes.py
+++ b/inquizitor/tests/api/api_v1/test_quizzes.py
@@ -23,6 +23,8 @@ class TestReadQuizzes:
         self, db: Session, client: AsyncClient, superuser_cookies: Dict[str, str]
     ) -> None:
         quiz = QuizFactory()
+        # override limit of 100, since quizzes are created in other tests
+        # and so far there is no mechanism implemented to refresh db
         r = await client.get("/quizzes/?limit=400", cookies=await superuser_cookies)
         result = r.json()
         assert r.status_code == 200

--- a/inquizitor/tests/api/api_v1/test_quizzes.py
+++ b/inquizitor/tests/api/api_v1/test_quizzes.py
@@ -314,7 +314,7 @@ class TestCreateQuiz:
         assert result["quiz_code"]
         assert result["teacher_id"] == quiz_in["teacher_id"]
 
-    async def test_create_quiz_teacher_is_author(
+    async def test_create_quiz_teacher(
         self, db: Session, client: AsyncClient, teacher_cookies: Dict[str, str]
     ) -> None:
         teacher_cookies = await teacher_cookies

--- a/inquizitor/tests/crud/test_action.py
+++ b/inquizitor/tests/crud/test_action.py
@@ -125,6 +125,25 @@ def test_get_multi_by_attempt_order_by_question(db: Session) -> None:
     )
     assert actions == actions_in_db
 
+# def test_get_per_student_summary_by_quiz(db: Session) -> None:
+#     actions = []
+#     quiz = factories.QuizFactory()
+#     for i in range(3):
+#         question = factories.QuestionFactory(quiz=quiz)
+#     quiz_in_db = crud.quiz.get(db, id=quiz.id)
+#     for i in range(5):
+#         student = factories.UserFactory(is_student=True)
+#         attempt = factories.AttemptFactory(student=student, quiz=quiz)
+#         for question in quiz_in_db.questions:
+#             for i in range(15):
+#                 action = factories.ActionFactory(question=question, attempt=attempt)
+#                 actions.append(action)
+
+#     summary = crud.quiz_action.get_per_student_summary_by_quiz(
+#         db, quiz_id=quiz.id
+#     )
+#     logging.info(f"{pformat(summary)}")
+
 def test_update_action(db: Session) -> None:
     quiz = factories.QuizFactory()
     question = factories.QuestionFactory(quiz=quiz)

--- a/inquizitor/tests/crud/test_action.py
+++ b/inquizitor/tests/crud/test_action.py
@@ -12,6 +12,12 @@ def test_create_action(db: Session) -> None:
     assert action.student == student
     assert action.focus == focus
 
+def test_create_multiple_actions(db: Session) -> None:
+    student = crud.user.get_by_username(db, username="student")
+    with pytest.raises(Exception) as e_info:
+        action_in = models.QuizActionCreate(focus=1, blur=1, double_click=1, student_id=student.id)
+        action = crud.quiz_action.create(db=db, obj_in=action_in)
+
 def test_get_action(db: Session) -> None:
     double_click = 1
     student = crud.user.get_by_username(db, username="student")
@@ -44,6 +50,7 @@ def test_remove_action(db: Session) -> None:
 
 def test_factory(db: Session) -> None:
     action = ActionFactory()
+    action2 = ActionFactory(custom=True, focus=1)
     assert sum([
         action.blur,
         action.focus,
@@ -53,15 +60,14 @@ def test_factory(db: Session) -> None:
         action.right_click,
         action.double_click,
     ]) == 1
-
-    # DOING
-    # action2 = ActionFactory(blur=1)
-    # assert sum([
-    #     action2.blur,
-    #     action2.focus,
-    #     action2.copy_,
-    #     action2.paste,
-    #     action2.left_click,
-    #     action2.right_click,
-    #     action2.double_click,
-    # ]) == 1
+    assert sum([
+        action2.blur,
+        action2.focus,
+        action2.copy_,
+        action2.paste,
+        action2.left_click,
+        action2.right_click,
+        action2.double_click,
+    ]) == 1
+    with pytest.raises(Exception) as e_info:
+        action2 = ActionFactory(custom=True, blur=1, copy=1)

--- a/inquizitor/tests/crud/test_action.py
+++ b/inquizitor/tests/crud/test_action.py
@@ -107,6 +107,24 @@ def test_get_multi_by_quiz_order_by_student(db: Session) -> None:
     )
     assert actions == actions_in_db
 
+def test_get_multi_by_attempt_order_by_question(db: Session) -> None:
+    actions = []
+    quiz = factories.QuizFactory()
+    for i in range(3):
+        question = factories.QuestionFactory(quiz=quiz)
+    student = factories.UserFactory(is_student=True)
+    attempt = factories.AttemptFactory(student=student, quiz=quiz)
+    quiz_in_db = crud.quiz.get(db, id=quiz.id)
+    for question in quiz_in_db.questions:
+        for i in range(5):
+            action = factories.ActionFactory(question=question, attempt=attempt)
+            actions.append(action)
+
+    actions_in_db = crud.quiz_action.get_multi_by_attempt_order_by_question(
+        db, attempt_id=attempt.id
+    )
+    assert actions == actions_in_db
+
 def test_update_action(db: Session) -> None:
     quiz = factories.QuizFactory()
     question = factories.QuestionFactory(quiz=quiz)

--- a/inquizitor/tests/crud/test_action.py
+++ b/inquizitor/tests/crud/test_action.py
@@ -1,0 +1,47 @@
+'''
+TEST CASES TO CONSIDER
+1. What happens when student/ attempt/ quiz/ question is deleted?
+'''
+
+import pytest
+from sqlmodel import Session
+
+from inquizitor import crud, models
+
+def test_create_action(db: Session) -> None:
+    focus = 1
+    student = crud.user.get_by_username(db, username="student")
+    action_in = models.QuizActionCreate(focus=focus, student_id=student.id)
+    action = crud.quiz_action.create(db=db, obj_in=action_in)
+    assert action.student == student
+    assert action.focus == focus
+
+def test_get_action(db: Session) -> None:
+    double_click = 1
+    student = crud.user.get_by_username(db, username="student")
+    action_in = models.QuizActionCreate(double_click=double_click, student_id=student.id)
+    action = crud.quiz_action.create(db=db, obj_in=action_in)
+    action_in_db = crud.quiz_action.get(db=db, id=action.id)
+    assert action_in_db.double_click == double_click
+    assert action_in_db.student == student
+
+def test_update_action(db: Session) -> None:
+    student = crud.user.get_by_username(db, username="student")
+    action_in = models.QuizActionCreate(blur=1, student_id=student.id)
+    action = crud.quiz_action.create(db=db, obj_in=action_in)
+
+    action_update = models.QuizActionUpdate(left_click=1, blur=0, student_id=student.id)
+    with pytest.raises(Exception) as e_info:
+        crud.quiz_action.update(db=db, db_obj=item, obj_in=item_update)
+
+def test_delete_action(db: Session) -> None:
+    focus = 1
+    student = crud.user.get_by_username(db, username="student")
+    action_in = models.QuizActionCreate(focus=focus, student_id=student.id)
+    action = crud.quiz_action.create(db=db, obj_in=action_in)
+    action2 = crud.quiz_action.remove(db=db, id=action.id)
+    action3 = crud.quiz_action.get(db=db, id=action.id)
+    assert action3 is None
+    assert action2.id == action.id
+    assert action2.student == action.student
+    assert action2.focus == action.focus

--- a/inquizitor/tests/crud/test_action.py
+++ b/inquizitor/tests/crud/test_action.py
@@ -1,12 +1,8 @@
-'''
-TEST CASES TO CONSIDER
-1. What happens when student/ attempt/ quiz/ question is deleted?
-'''
-
 import pytest
 from sqlmodel import Session
 
 from inquizitor import crud, models
+from inquizitor.tests.factories import ActionFactory 
 
 def test_create_action(db: Session) -> None:
     focus = 1
@@ -34,7 +30,7 @@ def test_update_action(db: Session) -> None:
     with pytest.raises(Exception) as e_info:
         crud.quiz_action.update(db=db, db_obj=item, obj_in=item_update)
 
-def test_delete_action(db: Session) -> None:
+def test_remove_action(db: Session) -> None:
     focus = 1
     student = crud.user.get_by_username(db, username="student")
     action_in = models.QuizActionCreate(focus=focus, student_id=student.id)
@@ -45,3 +41,27 @@ def test_delete_action(db: Session) -> None:
     assert action2.id == action.id
     assert action2.student == action.student
     assert action2.focus == action.focus
+
+def test_factory(db: Session) -> None:
+    action = ActionFactory()
+    assert sum([
+        action.blur,
+        action.focus,
+        action.copy_,
+        action.paste,
+        action.left_click,
+        action.right_click,
+        action.double_click,
+    ]) == 1
+
+    # DOING
+    # action2 = ActionFactory(blur=1)
+    # assert sum([
+    #     action2.blur,
+    #     action2.focus,
+    #     action2.copy_,
+    #     action2.paste,
+    #     action2.left_click,
+    #     action2.right_click,
+    #     action2.double_click,
+    # ]) == 1

--- a/inquizitor/tests/crud/test_action.py
+++ b/inquizitor/tests/crud/test_action.py
@@ -125,24 +125,47 @@ def test_get_multi_by_attempt_order_by_question(db: Session) -> None:
     )
     assert actions == actions_in_db
 
-# def test_get_per_student_summary_by_quiz(db: Session) -> None:
-#     actions = []
-#     quiz = factories.QuizFactory()
-#     for i in range(3):
-#         question = factories.QuestionFactory(quiz=quiz)
-#     quiz_in_db = crud.quiz.get(db, id=quiz.id)
-#     for i in range(5):
-#         student = factories.UserFactory(is_student=True)
-#         attempt = factories.AttemptFactory(student=student, quiz=quiz)
-#         for question in quiz_in_db.questions:
-#             for i in range(15):
-#                 action = factories.ActionFactory(question=question, attempt=attempt)
-#                 actions.append(action)
+def test_get_per_student_summary_by_quiz(db: Session) -> None:
+    quiz = factories.QuizFactory()
+    for i in range(3):
+        question = factories.QuestionFactory(quiz=quiz)
+    quiz_in_db = crud.quiz.get(db, id=quiz.id)
+    for i in range(5):
+        student = factories.UserFactory(is_student=True)
+        attempt = factories.AttemptFactory(student=student, quiz=quiz)
+        for question in quiz_in_db.questions:
+            for i in range(15):
+                action = factories.ActionFactory(question=question, attempt=attempt)
 
-#     summary = crud.quiz_action.get_per_student_summary_by_quiz(
-#         db, quiz_id=quiz.id
-#     )
-#     logging.info(f"{pformat(summary)}")
+    summary = crud.quiz_action.get_per_student_summary_by_quiz(
+        db, quiz_id=quiz.id
+    )
+    for student in summary:
+        action_count = 0
+        for action in summary[student].keys():
+            action_count += summary[student][action]
+        assert action_count == 45 # 3 questions, 15 actions each
+
+def test_get_per_question_summary_by_attempt(db: Session) -> None:
+    quiz = factories.QuizFactory()
+    for i in range(5):
+        question = factories.QuestionFactory(quiz=quiz)
+    student = factories.UserFactory(is_student=True)
+    attempt = factories.AttemptFactory(student=student, quiz=quiz)
+
+    quiz_in_db = crud.quiz.get(db, id=quiz.id)
+    for question in quiz_in_db.questions:
+        for i in range(20):
+            action = factories.ActionFactory(question=question, attempt=attempt)
+
+    summary = crud.quiz_action.get_per_question_summary_by_attempt(
+        db, attempt_id=attempt.id
+    )
+    for question in summary:
+        action_count = 0
+        for action in summary[question].keys():
+            action_count += summary[question][action]
+        assert action_count == 20 # 20 actions each
 
 def test_update_action(db: Session) -> None:
     quiz = factories.QuizFactory()

--- a/inquizitor/tests/crud/test_action.py
+++ b/inquizitor/tests/crud/test_action.py
@@ -1,8 +1,11 @@
+import logging
+import factory
 import pytest
 from sqlmodel import Session
+from pprint import pformat
 
 from inquizitor import crud, models
-from inquizitor.tests.factories import ActionFactory 
+from inquizitor.tests import factories 
 
 def test_create_action(db: Session) -> None:
     focus = 1
@@ -27,6 +30,72 @@ def test_get_action(db: Session) -> None:
     assert action_in_db.double_click == double_click
     assert action_in_db.student == student
 
+def test_get_multi_action_by_question_attempt(db: Session) -> None:
+    actions = []
+    student = factories.UserFactory(is_student=True)
+    quiz = factories.QuizFactory()
+    attempt = factories.AttemptFactory(student=student, quiz=quiz)
+    question = factories.QuestionFactory(quiz=quiz, attempt=attempt)
+    for i in range(3):
+        action = factories.ActionFactory(question=question, attempt=attempt)
+        actions.append(action)
+
+    actions_in_db = crud.quiz_action.get_multi_by_question_attempt(
+        db, question_id=question.id, attempt_id=attempt.id
+    )
+    assert actions == actions_in_db
+
+def test_get_multi_action_by_attempt(db: Session) -> None:
+    actions = []
+    student = factories.UserFactory(is_student=True)
+    quiz = factories.QuizFactory()
+    attempt = factories.AttemptFactory(student=student, quiz=quiz)
+    for i in range(3):
+        question = factories.QuestionFactory(quiz=quiz)
+    quiz_in_db = crud.quiz.get(db, id=quiz.id)
+    for question in quiz_in_db.questions:
+        action = factories.ActionFactory(question=question, attempt=attempt)
+        actions.append(action)
+
+    actions_in_db = crud.quiz_action.get_multi_by_attempt(
+        db, attempt_id=attempt.id
+    )
+    assert actions == actions_in_db
+
+def test_get_multi_action_by_question(db: Session) -> None:
+    actions = []
+    quiz = factories.QuizFactory()
+    question = factories.QuestionFactory(quiz=quiz)
+    for i in range(3):
+        student = factories.UserFactory(is_student=True)
+        attempt = factories.AttemptFactory(student=student, quiz=quiz)
+        action = factories.ActionFactory(question=question, attempt=attempt)
+        actions.append(action)
+
+    actions_in_db = crud.quiz_action.get_multi_by_question(
+        db, question_id=question.id
+    )
+    assert actions == actions_in_db
+
+def test_get_multi_by_quiz_order_by_student(db: Session) -> None:
+    actions = []
+    quiz = factories.QuizFactory()
+    for i in range(3):
+        question = factories.QuestionFactory(quiz=quiz)
+    quiz_in_db = crud.quiz.get(db, id=quiz.id)
+    for i in range(3):
+        student = factories.UserFactory(is_student=True)
+        attempt = factories.AttemptFactory(student=student, quiz=quiz)
+        for question in quiz_in_db.questions:
+            for i in range(5):
+                action = factories.ActionFactory(question=question, attempt=attempt)
+                actions.append(action)
+
+    actions_in_db = crud.quiz_action.get_multi_by_quiz_order_by_student(
+        db, quiz_id=quiz.id
+    )
+    assert actions == actions_in_db
+
 def test_update_action(db: Session) -> None:
     student = crud.user.get_by_username(db, username="student")
     action_in = models.QuizActionCreate(blur=1, student_id=student.id)
@@ -49,8 +118,8 @@ def test_remove_action(db: Session) -> None:
     assert action2.focus == action.focus
 
 def test_factory(db: Session) -> None:
-    action = ActionFactory()
-    action2 = ActionFactory(custom=True, focus=1)
+    action = factories.ActionFactory()
+    action2 = factories.ActionFactory(custom=True, focus=1)
     assert sum([
         action.blur,
         action.focus,
@@ -70,4 +139,4 @@ def test_factory(db: Session) -> None:
         action2.double_click,
     ]) == 1
     with pytest.raises(Exception) as e_info:
-        action2 = ActionFactory(custom=True, blur=1, copy=1)
+        action2 = factories.ActionFactory(custom=True, blur=1, copy_=1)

--- a/inquizitor/tests/factories.py
+++ b/inquizitor/tests/factories.py
@@ -210,13 +210,15 @@ class ActionFactory(BaseFactory):
         # i.e. action = ActionFactory(custom=True, focus=1)
         custom: bool = False 
 
-    blur: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
-    focus: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
-    copy_: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
-    paste: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
-    left_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
-    right_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
-    double_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    time = factory.LazyFunction(dt.datetime.now)
+
+    blur = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    focus = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    copy_ = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    paste = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    left_click = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    right_click = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    double_click = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
 
     attempt_id: int = factory.LazyAttribute(
         lambda a: a.attempt.id if a.attempt is not None else None

--- a/inquizitor/tests/factories.py
+++ b/inquizitor/tests/factories.py
@@ -1,8 +1,10 @@
 import datetime as dt
 import factory
+import logging
 import random
 from factory.alchemy import SQLAlchemyModelFactory
 from fastapi.encoders import jsonable_encoder
+from pprint import pformat
 from typing import List, Optional, Union
 
 from inquizitor import models
@@ -201,19 +203,22 @@ class ActionFactory(BaseFactory):
         attempt: models.QuizAttempt = factory.SubFactory(AttemptFactory)
         quiz: models.Quiz = factory.SubFactory(QuizFactory)
         question: models.QuizQuestion = factory.SubFactory(QuestionFactory)
-        
+
         ACTIONS: List[int] = [1,0,0,0,0,0,0]
         random_action: list = factory.LazyAttribute(
             lambda a: random.sample(a.ACTIONS, len(a.ACTIONS))
         )
+        # set to True when creating an object with a custom action 
+        # i.e. action = ActionFactory(custom=True, focus=1)
+        custom: bool = False 
 
-    blur: int = factory.LazyAttribute(lambda a: a.random_action.pop())
-    focus: int = factory.LazyAttribute(lambda a: a.random_action.pop())
-    copy_: int = factory.LazyAttribute(lambda a: a.random_action.pop())
-    paste: int = factory.LazyAttribute(lambda a: a.random_action.pop())
-    left_click: int = factory.LazyAttribute(lambda a: a.random_action.pop())
-    right_click: int = factory.LazyAttribute(lambda a: a.random_action.pop())
-    double_click: int = factory.LazyAttribute(lambda a: a.random_action.pop())
+    blur: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    focus: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    copy_: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    paste: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    left_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    right_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
+    double_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
 
     student_id: int = factory.LazyAttribute(
         lambda a: a.student.id if a.student is not None else None

--- a/inquizitor/tests/factories.py
+++ b/inquizitor/tests/factories.py
@@ -2,9 +2,8 @@ import datetime as dt
 import factory
 import random
 from factory.alchemy import SQLAlchemyModelFactory
-from typing import List, Optional, Union
-
 from fastapi.encoders import jsonable_encoder
+from typing import List, Optional, Union
 
 from inquizitor import models
 from inquizitor.crud.base import CreateSchemaType, ModelType, UpdateSchemaType
@@ -20,7 +19,6 @@ from inquizitor.tests import common
 
 #     class Meta:
 #         model = models.This
-
 
 class BaseFactory(SQLAlchemyModelFactory):
     """Base factory."""
@@ -45,7 +43,6 @@ class BaseFactory(SQLAlchemyModelFactory):
         cls._meta.model = cls.model
         return jsonable_encoder(x)
 
-
 # TODO for update: check new attributes
 class UserFactory(BaseFactory):
     """User factory."""
@@ -66,7 +63,6 @@ class UserFactory(BaseFactory):
     model: ModelType = models.User
     create_schema: CreateSchemaType = models.UserCreate
     update_schema: UpdateSchemaType = models.UserUpdate
-
 
 class QuizFactory(BaseFactory):
     """Quiz factory."""
@@ -96,7 +92,6 @@ class QuizFactory(BaseFactory):
     create_schema: CreateSchemaType = models.QuizCreate
     update_schema: UpdateSchemaType = models.QuizUpdate
 
-
 class QuestionFactory(BaseFactory):
     """Question factory."""
 
@@ -117,7 +112,6 @@ class QuestionFactory(BaseFactory):
     create_schema: CreateSchemaType = models.QuizQuestionCreate
     update_schema: UpdateSchemaType = models.QuizQuestionUpdate
 
-
 class ChoiceFactory(BaseFactory):
     """Choice factory."""
 
@@ -136,7 +130,6 @@ class ChoiceFactory(BaseFactory):
     model: ModelType = models.QuizChoice
     create_schema: CreateSchemaType = models.QuizChoiceCreate
     update_schema: UpdateSchemaType = models.QuizChoiceUpdate
-
 
 class AttemptFactory(BaseFactory):
     """Attempt factory."""
@@ -165,7 +158,6 @@ class AttemptFactory(BaseFactory):
     model: ModelType = models.QuizAttempt
     create_schema: CreateSchemaType = models.QuizAttemptCreate
     update_schema: UpdateSchemaType = models.QuizAttemptUpdate
-
 
 class AnswerFactory(BaseFactory):
     """Answer factory."""
@@ -197,3 +189,45 @@ class AnswerFactory(BaseFactory):
     model: ModelType = models.QuizAnswer
     create_schema: CreateSchemaType = models.QuizAnswerCreate
     update_schema: UpdateSchemaType = models.QuizAnswerUpdate
+
+class ActionFactory(BaseFactory):
+    """Action factory."""
+
+    class Meta:
+        model = models.QuizAction
+
+    class Params:
+        student: models.User = factory.SubFactory(UserFactory)
+        attempt: models.QuizAttempt = factory.SubFactory(AttemptFactory)
+        quiz: models.Quiz = factory.SubFactory(QuizFactory)
+        question: models.QuizQuestion = factory.SubFactory(QuestionFactory)
+        
+        ACTIONS: List[int] = [1,0,0,0,0,0,0]
+        random_action: list = factory.LazyAttribute(
+            lambda a: random.sample(a.ACTIONS, len(a.ACTIONS))
+        )
+
+    blur: int = factory.LazyAttribute(lambda a: a.random_action.pop())
+    focus: int = factory.LazyAttribute(lambda a: a.random_action.pop())
+    copy_: int = factory.LazyAttribute(lambda a: a.random_action.pop())
+    paste: int = factory.LazyAttribute(lambda a: a.random_action.pop())
+    left_click: int = factory.LazyAttribute(lambda a: a.random_action.pop())
+    right_click: int = factory.LazyAttribute(lambda a: a.random_action.pop())
+    double_click: int = factory.LazyAttribute(lambda a: a.random_action.pop())
+
+    student_id: int = factory.LazyAttribute(
+        lambda a: a.student.id if a.student is not None else None
+    )
+    attempt_id: int = factory.LazyAttribute(
+        lambda a: a.attempt.id if a.attempt is not None else None
+    )
+    quiz_id: int = factory.LazyAttribute(
+        lambda a: a.quiz.id if a.quiz is not None else None
+    )
+    question_id: int = factory.LazyAttribute(
+        lambda a: a.question.id if a.question is not None else None
+    )
+
+    model: ModelType = models.QuizAction
+    create_schema: CreateSchemaType = models.QuizActionCreate
+    update_schema: UpdateSchemaType = models.QuizActionUpdate

--- a/inquizitor/tests/factories.py
+++ b/inquizitor/tests/factories.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import factory
-import logging
 import random
+import string
 from factory.alchemy import SQLAlchemyModelFactory
 from fastapi.encoders import jsonable_encoder
 from pprint import pformat
@@ -52,8 +52,8 @@ class UserFactory(BaseFactory):
     class Meta:
         model = models.User
 
-    username = factory.Faker("user_name")
-    email = factory.Faker("email")
+    username = factory.LazyAttribute(lambda a: f"{fake.user_name()}{random.randint(1,1000)}")
+    email = factory.LazyAttribute(lambda a: f"{fake.email()}{''.join(random.sample(string.ascii_lowercase, 2))}")
     full_name = factory.Faker("name")
     last_name = factory.Faker("last_name")
     first_name = factory.Faker("first_name")
@@ -204,9 +204,9 @@ class ActionFactory(BaseFactory):
         quiz: models.Quiz = factory.SubFactory(QuizFactory)
         question: models.QuizQuestion = factory.SubFactory(QuestionFactory)
 
-        ACTIONS: List[int] = [1,0,0,0,0,0,0]
+        ACTIONS: List[int] = [0,0,0,0,1,0,0]
         random_action: list = factory.LazyAttribute(
-            lambda a: random.sample(a.ACTIONS, len(a.ACTIONS))
+            lambda a: list(random.sample(a.ACTIONS, len(a.ACTIONS)))
         )
         # set to True when creating an object with a custom action 
         # i.e. action = ActionFactory(custom=True, focus=1)
@@ -221,13 +221,13 @@ class ActionFactory(BaseFactory):
     double_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
 
     student_id: int = factory.LazyAttribute(
-        lambda a: a.student.id if a.student is not None else None
+        lambda a: a.attempt.student_id if a.attempt else None
     )
     attempt_id: int = factory.LazyAttribute(
-        lambda a: a.attempt.id if a.attempt is not None else None
+        lambda a: a.attempt.id if a.attempt  else None
     )
     quiz_id: int = factory.LazyAttribute(
-        lambda a: a.quiz.id if a.quiz is not None else None
+        lambda a: a.question.quiz_id if a.question else None
     )
     question_id: int = factory.LazyAttribute(
         lambda a: a.question.id if a.question is not None else None

--- a/inquizitor/tests/factories.py
+++ b/inquizitor/tests/factories.py
@@ -199,9 +199,7 @@ class ActionFactory(BaseFactory):
         model = models.QuizAction
 
     class Params:
-        student: models.User = factory.SubFactory(UserFactory)
         attempt: models.QuizAttempt = factory.SubFactory(AttemptFactory)
-        quiz: models.Quiz = factory.SubFactory(QuizFactory)
         question: models.QuizQuestion = factory.SubFactory(QuestionFactory)
 
         ACTIONS: List[int] = [0,0,0,0,1,0,0]
@@ -220,14 +218,8 @@ class ActionFactory(BaseFactory):
     right_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
     double_click: int = factory.LazyAttribute(lambda a: 0 if a.custom else a.random_action.pop())
 
-    student_id: int = factory.LazyAttribute(
-        lambda a: a.attempt.student_id if a.attempt else None
-    )
     attempt_id: int = factory.LazyAttribute(
-        lambda a: a.attempt.id if a.attempt  else None
-    )
-    quiz_id: int = factory.LazyAttribute(
-        lambda a: a.question.quiz_id if a.question else None
+        lambda a: a.attempt.id if a.attempt is not None else None
     )
     question_id: int = factory.LazyAttribute(
         lambda a: a.question.id if a.question is not None else None


### PR DESCRIPTION
## Description
- Implements https://github.com/Iionsroar/inquizitor/issues/31
- New endpoints are:
  ![image](https://user-images.githubusercontent.com/65220389/185053051-c35e823e-93c1-4fb0-b102-fdcd2e627f38.png)

## Frontend To-Dos
- [ ] Explore new features
    - Checkout branch `31-storing-input-device-data`
    - Reset database to access new initial data (quiz actions) 
- [ ] Implement feature for storing input device data
- [ ] Raise suggestions/ concerns/ issues on this page